### PR TITLE
fix: repair scaffolder output, Studio RAG graph, and server hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ graph TD
 | **Observe** | LangSmith Tracing | Full observability with one env var |
 | **Persist** | Memory + Postgres | In-memory for dev, PostgreSQL-ready for production |
 | **Deploy** | Docker + CI | Docker Compose with Postgres, GitHub Actions CI |
-| **Test** | 39 Tests | Tools, config, agents, offline multi-agent flows — all tested with vitest |
+| **Test** | 45 Tests | Tools, config, agents, request validation, offline multi-agent flows — all with vitest |
 
 ## Quick Start
 

--- a/create-langgraph-app/create.ts
+++ b/create-langgraph-app/create.ts
@@ -142,6 +142,7 @@ function generatePackageJson(config: Config): string {
       dev: "tsx src/index.ts",
       "dev:http": "tsx src/server.ts",
       test: "vitest run",
+      "test:watch": "vitest",
       typecheck: "tsc --noEmit",
     },
     dependencies: Object.fromEntries(
@@ -172,7 +173,7 @@ function generateTsConfig(): string {
         types: ["node"],
         outDir: "dist",
       },
-      include: ["src"],
+      include: ["src", "tests"],
     },
     null,
     2
@@ -390,6 +391,261 @@ export function makeSupervisor({
     checkpointer: checkpointer ?? new MemorySaver(),
   });
 }
+`;
+}
+
+// Maps a selected pattern to the app it generates, so the server and demos
+// only reference files that actually exist.
+const PATTERN_APPS: Record<string, { route: string; fn: string; path: string }> = {
+  supervisor: { route: "supervisor", fn: "createSupervisorApp", path: "./apps/supervisor" },
+  swarm: { route: "swarm", fn: "createSwarmApp", path: "./apps/swarm" },
+  hitl: { route: "interrupt", fn: "createInterruptApp", path: "./apps/interrupt" },
+  structured: { route: "analyst", fn: "createAnalystApp", path: "./apps/analyst" },
+  rag: { route: "rag", fn: "createRagApp", path: "./apps/rag" },
+};
+
+function selectedApps(config: Config) {
+  return config.patterns.map((p) => PATTERN_APPS[p]).filter(Boolean);
+}
+
+function generateServer(config: Config): string {
+  const apps = selectedApps(config);
+  const imports = apps.map((a) => `import { ${a.fn} } from "${a.path}";`).join("\n");
+  const entries = apps.map((a) => `    "${a.route}": asApp(await ${a.fn}()),`).join("\n");
+
+  return `import "./config/env";
+import { fastify, type FastifyError, type FastifyReply, type FastifyRequest } from "fastify";
+import { Command } from "@langchain/langgraph";
+import { AIMessageChunk, type BaseMessage } from "@langchain/core/messages";
+import { PORT } from "./config/env";
+${imports}
+
+// The apps are a mix of agents and graphs whose generic types don't unify;
+// this is the structural slice the routes actually need.
+interface AppGraph {
+  invoke(input: unknown, config?: unknown): Promise<{ messages: BaseMessage[] } & Record<string, unknown>>;
+  stream(input: unknown, config?: unknown): Promise<AsyncIterable<[unknown, { langgraph_node?: string } | undefined]>>;
+  getState(config: unknown): Promise<{ values?: unknown; next?: string[]; tasks?: unknown[] } | undefined>;
+}
+const asApp = (g: unknown) => g as AppGraph;
+
+function httpError(status: number, message: string) {
+  return Object.assign(new Error(message), { statusCode: status });
+}
+
+/** Reject malformed bodies before they reach the agent. */
+function validateMessages(raw: unknown): { role: string; content: string }[] {
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw)) throw httpError(400, '"messages" must be an array');
+  return raw.map((m, i) => {
+    const { role, content } = (m ?? {}) as Record<string, unknown>;
+    if (typeof role !== "string" || typeof content !== "string") {
+      throw httpError(400, \`messages[\${i}] needs string "role" and "content"\`);
+    }
+    return { role, content };
+  });
+}
+
+const server = fastify({ logger: false });
+
+server.setErrorHandler(async (error: FastifyError, _req: FastifyRequest, reply: FastifyReply) => {
+  const status = error.statusCode ?? 500;
+  return reply.status(status).send({ error: error.message });
+});
+
+async function start() {
+  const apps: Record<string, AppGraph> = {
+${entries}
+  };
+
+  const getApp = (name: string) => {
+    const app = apps[name];
+    if (!app) throw httpError(404, \`Unknown app: "\${name}". Available: \${Object.keys(apps).join(", ")}\`);
+    return app;
+  };
+
+  server.post<{ Params: { app: string } }>("/:app/invoke", async (req, reply) => {
+    const app = getApp(req.params.app);
+    const body = (req.body ?? {}) as { messages?: unknown; thread_id?: string };
+    const messages = validateMessages(body.messages);
+    const thread_id = body.thread_id ?? "default";
+
+    const result = await app.invoke({ messages }, { configurable: { thread_id } });
+    const last = result.messages.at(-1);
+    return reply.send({
+      messages: result.messages,
+      structuredResponse: (result as Record<string, unknown>).structuredResponse ?? null,
+      lastMessage: typeof last?.content === "string" ? last.content : JSON.stringify(last?.content),
+    });
+  });
+
+  server.post<{ Params: { app: string } }>("/:app/stream", async (req, reply) => {
+    const app = getApp(req.params.app);
+    const body = (req.body ?? {}) as { messages?: unknown; thread_id?: string };
+    const messages = validateMessages(body.messages);
+    const thread_id = body.thread_id ?? "default";
+
+    reply.raw.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    const send = (e: unknown) => reply.raw.write(\`data: \${JSON.stringify(e)}\\n\\n\`);
+
+    try {
+      const stream = await app.stream({ messages }, { configurable: { thread_id }, streamMode: "messages" });
+      for await (const [chunk, metadata] of stream) {
+        if (chunk instanceof AIMessageChunk) {
+          send({ type: "token", content: chunk.content, node: metadata?.langgraph_node ?? "unknown" });
+        }
+      }
+      send({ type: "done" });
+    } catch (err) {
+      send({ type: "error", content: err instanceof Error ? err.message : "Stream failed" });
+    } finally {
+      reply.raw.end();
+    }
+  });
+
+  server.post<{ Params: { app: string } }>("/:app/resume", async (req, reply) => {
+    const app = getApp(req.params.app);
+    const body = (req.body ?? {}) as { thread_id?: string; decision?: string };
+    if (body.decision === undefined) {
+      return reply.status(400).send({ error: '"decision" field is required' });
+    }
+    const result = await app.invoke(new Command({ resume: body.decision }), {
+      configurable: { thread_id: body.thread_id ?? "default" },
+    });
+    const last = result.messages.at(-1);
+    return reply.send({
+      messages: result.messages,
+      lastMessage: typeof last?.content === "string" ? last.content : JSON.stringify(last?.content),
+    });
+  });
+
+  server.get<{ Params: { app: string; threadId: string } }>("/:app/threads/:threadId", async (req, reply) => {
+    const app = getApp(req.params.app);
+    const state = await app.getState({ configurable: { thread_id: req.params.threadId } });
+    if (!state?.values) return reply.status(404).send({ error: "Thread not found" });
+    return reply.send({ values: state.values, next: state.next ?? [], tasks: state.tasks ?? [] });
+  });
+
+  server.get("/health", async () => ({ status: "ok", apps: Object.keys(apps) }));
+
+  // Container runtimes send SIGTERM on stop — drain instead of dying mid-request.
+  let shuttingDown = false;
+  for (const signal of ["SIGTERM", "SIGINT"] as const) {
+    process.on(signal, () => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      server.close().then(() => process.exit(0)).catch(() => process.exit(1));
+    });
+  }
+
+  await server.listen({ port: PORT, host: "0.0.0.0" });
+  console.log(\`Server running at http://localhost:\${PORT}\`);
+  console.log(\`Apps: \${Object.keys(apps).join(", ")}\`);
+}
+
+start().catch((err) => {
+  console.error("Failed to start server:", err);
+  process.exit(1);
+});
+`;
+}
+
+function generateScriptedModel(): string {
+  return `import { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { AIMessage, type BaseMessage } from "@langchain/core/messages";
+import type { ChatResult } from "@langchain/core/outputs";
+
+/**
+ * A model that replays a queued list of responses, so tests can drive real
+ * graphs offline — no API key, no network, fully deterministic.
+ */
+export class ScriptedToolCallingModel extends BaseChatModel {
+  private queue: AIMessage[];
+
+  constructor(queue: AIMessage[]) {
+    super({});
+    this.queue = [...queue];
+  }
+
+  _llmType(): string {
+    return "scripted-tool-calling";
+  }
+
+  override bindTools(): this {
+    return this;
+  }
+
+  async _generate(_messages: BaseMessage[]): Promise<ChatResult> {
+    const message = this.queue.shift();
+    if (!message) throw new Error("Scripted model ran out of responses");
+    return { generations: [{ message, text: "" }] };
+  }
+}
+`;
+}
+
+function generateAgentTest(config: Config): string {
+  const hasSupervisor = config.patterns.includes("supervisor");
+
+  const supervisorTest = hasSupervisor
+    ? `
+  it("delegates to a subagent and returns its answer", async () => {
+    const llm = new ScriptedToolCallingModel([
+      // supervisor delegates
+      new AIMessage({
+        content: "",
+        tool_calls: [{ id: "c1", name: "worker", args: { task: "do the thing" } }],
+      }),
+      // subagent answers
+      new AIMessage("worker done"),
+      // supervisor wraps up
+      new AIMessage("All finished."),
+    ]);
+
+    const worker = makeAgent({ name: "worker", llm, tools: [] });
+    const app = await makeSupervisor({
+      subagents: [{ name: "worker", description: "Does the thing.", agent: worker }],
+      llm,
+      checkpointer: new MemorySaver(),
+    });
+
+    const result = await app.invoke(
+      { messages: [{ role: "user", content: "do the thing" }] },
+      { configurable: { thread_id: "t1" } }
+    );
+
+    expect(result.messages.at(-1)?.content).toBe("All finished.");
+    // the supervisor sees the subagent's final answer, not its internals
+    const toolMessages = result.messages.filter((m) => m.getType() === "tool");
+    expect(toolMessages).toHaveLength(1);
+    expect(toolMessages[0].content).toBe("worker done");
+  });
+`
+    : "";
+
+  const supervisorImports = hasSupervisor
+    ? `import { makeSupervisor } from "../src/agents/supervisor";\nimport { MemorySaver } from "@langchain/langgraph";\n`
+    : "";
+
+  return `import { describe, expect, it } from "vitest";
+import { AIMessage } from "@langchain/core/messages";
+import { makeAgent } from "../src/agents/factory";
+${supervisorImports}import { ScriptedToolCallingModel } from "./helpers/scripted-model";
+
+describe("agents", () => {
+  it("runs a single agent to a final answer", async () => {
+    const llm = new ScriptedToolCallingModel([new AIMessage("Hello there.")]);
+    const agent = makeAgent({ name: "assistant", llm, tools: [], system: "Be brief." });
+
+    const result = await agent.invoke({ messages: [{ role: "user", content: "hi" }] });
+
+    expect(result.messages.at(-1)?.content).toBe("Hello there.");
+  });
+${supervisorTest}});
 `;
 }
 
@@ -773,6 +1029,13 @@ export async function createRagApp() {
   );
   console.log("Result:", rag.messages.at(-1)?.content);`);
   }
+
+  // HTTP server — routes only the apps that were generated
+  files.push({ path: "src/server.ts", content: generateServer(config) });
+
+  // Tests — offline, no API key needed
+  files.push({ path: "tests/helpers/scripted-model.ts", content: generateScriptedModel() });
+  files.push({ path: "tests/agents.test.ts", content: generateAgentTest(config) });
 
   // Generate index.ts
   files.push({

--- a/create-langgraph-app/package.json
+++ b/create-langgraph-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-langgraph-app",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Scaffold a new LangGraph multi-agent project in seconds",
   "type": "module",
   "bin": {

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -15,6 +15,7 @@ that aren't obvious until they bite you.
 - [Checkpointers and interrupts — the rule that matters](#checkpointers-and-interrupts--the-rule-that-matters)
 - [Structured output](#structured-output)
 - [Persistence and threads](#persistence-and-threads)
+- [What the HTTP server does for you](#what-the-http-server-does-for-you)
 - [Testing without an API key](#testing-without-an-api-key)
 - [Wiring a new app into the kit](#wiring-a-new-app-into-the-kit)
 - [MCP tools](#mcp-tools)
@@ -68,6 +69,7 @@ const agent = makeAgent({
   system: "You are ...",       // optional system prompt
   responseFormat: ...,         // optional, see Structured output
   checkpointer: ...,           // optional — ONLY for the outermost agent
+  store: ...,                  // optional cross-thread store, outermost only
 });
 ```
 
@@ -254,6 +256,25 @@ wiring problem.
 
 `GET /:app/threads/:id` and `GET /:app/threads/:id/history` expose thread
 state over HTTP.
+
+`makeSupervisor` and `makeSwarm` also accept an optional `store` (cross-thread
+memory, `InMemoryStore` by default). Like the checkpointer it belongs on the
+outermost graph only. If you pass your own `checkpointer`, pass your own
+`store` too — the kit only auto-creates them together.
+
+## What the HTTP server does for you
+
+Beyond the routes listed in the README, `src/server/index.ts` handles:
+
+- **Validation** — `messages` is checked before it reaches LangGraph
+  (`src/server/validation.ts`). A malformed body returns **400** instead of
+  running the agent on coerced garbage.
+- **404 for unknown apps** — requesting an app that isn't registered returns
+  404, not 500.
+- **Graceful shutdown** — `SIGTERM`/`SIGINT` drain in-flight requests via
+  `server.close()`, which also fires the `onClose` hook that closes the MCP
+  client. Container runtimes (Docker, Railway, Render) send `SIGTERM` on stop,
+  so without this the process would die mid-request.
 
 ## Testing without an API key
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langgraph-starter-kit",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Production-ready multi-agent starter kit with LangGraph — supports swarm, supervisor, HITL, structured output, and 5 LLM providers",
   "private": true,
   "type": "module",

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -1,6 +1,6 @@
 import { createAgent, type ResponseFormat, type TypedToolStrategy } from "langchain";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
-import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint";
+import type { BaseCheckpointSaver, BaseStore } from "@langchain/langgraph-checkpoint";
 
 type CreateAgentParams = Parameters<typeof createAgent>[0];
 
@@ -16,6 +16,8 @@ export interface MakeAgentParams {
    * `interrupt()` calls bubble up to the top-level graph.
    */
   checkpointer?: BaseCheckpointSaver;
+  /** Cross-thread memory store. Like `checkpointer`, set it on the outermost agent only. */
+  store?: BaseStore;
 }
 
 /**
@@ -33,6 +35,7 @@ export function makeAgent({
   system,
   responseFormat,
   checkpointer,
+  store,
 }: MakeAgentParams) {
   return createAgent({
     name,
@@ -41,6 +44,7 @@ export function makeAgent({
     ...(system ? { systemPrompt: system } : {}),
     ...(responseFormat ? { responseFormat } : {}),
     ...(checkpointer ? { checkpointer } : {}),
+    ...(store ? { store } : {}),
   });
 }
 

--- a/src/agents/supervisor.ts
+++ b/src/agents/supervisor.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { tool } from "@langchain/core/tools";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
-import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint";
+import type { BaseCheckpointSaver, BaseStore } from "@langchain/langgraph-checkpoint";
 import { makeAgent, type AgentGraph } from "./factory";
 
 /**
@@ -58,6 +58,7 @@ export interface MakeSupervisorParams {
   supervisorName?: string;
   prompt?: string;
   checkpointer?: BaseCheckpointSaver;
+  store?: BaseStore;
 }
 
 export async function makeSupervisor({
@@ -66,6 +67,7 @@ export async function makeSupervisor({
   supervisorName = "supervisor",
   prompt,
   checkpointer,
+  store,
 }: MakeSupervisorParams) {
   const defaultPrompt =
     "You coordinate a team of specialists. Delegate work to them via " +
@@ -74,9 +76,15 @@ export async function makeSupervisor({
 
   // Lazy import: config/env validates provider API keys at import time,
   // which callers supplying their own checkpointer (e.g. tests) shouldn't
-  // have to satisfy.
-  const resolvedCheckpointer =
-    checkpointer ?? (await (await import("../config/checkpointer")).getCheckpointer());
+  // have to satisfy. Callers that bring their own checkpointer are expected
+  // to bring their own store too, if they want one.
+  let resolvedCheckpointer = checkpointer;
+  let resolvedStore = store;
+  if (!resolvedCheckpointer) {
+    const config = await import("../config/checkpointer");
+    resolvedCheckpointer = await config.getCheckpointer();
+    resolvedStore ??= config.getStore();
+  }
 
   return makeAgent({
     name: supervisorName,
@@ -84,5 +92,6 @@ export async function makeSupervisor({
     tools: subagents.map(subagentTool),
     system: prompt ?? defaultPrompt,
     checkpointer: resolvedCheckpointer,
+    store: resolvedStore,
   });
 }

--- a/src/agents/swarm.ts
+++ b/src/agents/swarm.ts
@@ -7,7 +7,7 @@ import {
   START,
   END,
 } from "@langchain/langgraph";
-import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint";
+import type { BaseCheckpointSaver, BaseStore } from "@langchain/langgraph-checkpoint";
 import type { AgentGraph } from "./factory";
 
 /**
@@ -38,12 +38,14 @@ export interface MakeSwarmParams {
   agents: SwarmAgentSpec[];
   defaultActiveAgent: string;
   checkpointer?: BaseCheckpointSaver;
+  store?: BaseStore;
 }
 
 export async function makeSwarm({
   agents,
   defaultActiveAgent,
   checkpointer,
+  store,
 }: MakeSwarmParams) {
   const names = agents.map((a) => a.name);
 
@@ -83,11 +85,18 @@ export async function makeSwarm({
 
   // Lazy import: config/env validates provider API keys at import time,
   // which callers supplying their own checkpointer (e.g. tests) shouldn't
-  // have to satisfy.
-  const resolvedCheckpointer =
-    checkpointer ?? (await (await import("../config/checkpointer")).getCheckpointer());
+  // have to satisfy. Callers that bring their own checkpointer are expected
+  // to bring their own store too, if they want one.
+  let resolvedCheckpointer = checkpointer;
+  let resolvedStore = store;
+  if (!resolvedCheckpointer) {
+    const config = await import("../config/checkpointer");
+    resolvedCheckpointer = await config.getCheckpointer();
+    resolvedStore ??= config.getStore();
+  }
 
   return builder.compile({
     checkpointer: resolvedCheckpointer,
+    store: resolvedStore,
   });
 }

--- a/src/apps/rag.ts
+++ b/src/apps/rag.ts
@@ -26,9 +26,15 @@ export async function initRagStore(
   return _vectorStore;
 }
 
-export async function createRagApp(vectorStore: InMemoryVectorStore) {
+/**
+ * `vectorStore` is optional so this factory can be registered directly in
+ * `langgraph.json` — LangGraph Studio calls graph factories with no vector
+ * store, and initRagStore() is memoized, so passing one is just an
+ * optimization for callers that already built it.
+ */
+export async function createRagApp(vectorStore?: InMemoryVectorStore) {
   const llm = await getLlm();
-  const retrievalTool = createRetrievalTool(vectorStore);
+  const retrievalTool = createRetrievalTool(vectorStore ?? (await initRagStore()));
 
   // A single agent with a retrieval tool — no supervisor layer needed.
   return makeAgent({

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,6 +10,7 @@ import { createResearcherApp } from "../apps/researcher";
 import { createRagApp, initRagStore } from "../apps/rag";
 import { createSupportApp } from "../apps/support";
 import { loadMcpTools } from "../tools/mcp";
+import { httpError, validateMessages } from "./validation";
 
 // -- Types --
 
@@ -104,7 +105,7 @@ export async function startServer(): Promise<void> {
 
   function getApp(name: string) {
     if (!(name in apps)) {
-      throw new Error(`Unknown app: "${name}". Available: ${Object.keys(apps).join(", ")}`);
+      throw httpError(404, `Unknown app: "${name}". Available: ${Object.keys(apps).join(", ")}`);
     }
     return apps[name as AppName];
   }
@@ -113,7 +114,8 @@ export async function startServer(): Promise<void> {
 
   server.post<{ Params: { app: string } }>("/:app/invoke", async (req, reply) => {
     const app = getApp(req.params.app);
-    const { messages = [], thread_id = "default" } = parseBody<InvokeBody>(req.body);
+    const { messages: rawMessages, thread_id = "default" } = parseBody<InvokeBody>(req.body);
+    const messages = validateMessages(rawMessages);
 
     const result = await app.invoke(
       { messages },
@@ -129,7 +131,8 @@ export async function startServer(): Promise<void> {
 
   server.post<{ Params: { app: string } }>("/:app/stream", async (req, reply) => {
     const app = getApp(req.params.app);
-    const { messages = [], thread_id = "default" } = parseBody<InvokeBody>(req.body);
+    const { messages: rawMessages, thread_id = "default" } = parseBody<InvokeBody>(req.body);
+    const messages = validateMessages(rawMessages);
 
     reply.raw.writeHead(200, {
       "Content-Type": "text/event-stream",
@@ -239,6 +242,30 @@ export async function startServer(): Promise<void> {
       // MCP client cleanup is best-effort
     }
   });
+
+  // -- Graceful shutdown --
+
+  // Container runtimes (Docker, Railway, Render) send SIGTERM on stop. Without
+  // this, Node exits immediately: in-flight requests are cut off and Fastify's
+  // onClose hook above never runs, so the MCP client is never closed.
+  let shuttingDown = false;
+  for (const signal of ["SIGTERM", "SIGINT"] as const) {
+    process.on(signal, () => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+      console.log(`\n${signal} received — draining connections...`);
+      server
+        .close()
+        .then(() => {
+          console.log("Shutdown complete.");
+          process.exit(0);
+        })
+        .catch((err: unknown) => {
+          console.error("Error during shutdown:", err);
+          process.exit(1);
+        });
+    });
+  }
 
   // -- Listen --
 

--- a/src/server/validation.ts
+++ b/src/server/validation.ts
@@ -1,0 +1,32 @@
+/**
+ * Request validation helpers, kept in their own module (free of any
+ * `config/env` import) so they can be unit-tested without API keys and
+ * without booting the server.
+ */
+
+/** An error carrying an HTTP status, so the error handler doesn't default to 500. */
+export function httpError(status: number, message: string): Error & { statusCode: number } {
+  return Object.assign(new Error(message), { statusCode: status });
+}
+
+/**
+ * Validates the `messages` array before it reaches LangGraph. Without this a
+ * malformed body (e.g. `"messages": "hi"`) is silently coerced into a message
+ * and the agent runs on garbage, returning 200.
+ */
+export function validateMessages(raw: unknown): { role: string; content: string }[] {
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw)) {
+    throw httpError(400, '"messages" must be an array');
+  }
+  return raw.map((m, i) => {
+    if (typeof m !== "object" || m === null) {
+      throw httpError(400, `messages[${i}] must be an object with "role" and "content"`);
+    }
+    const { role, content } = m as Record<string, unknown>;
+    if (typeof role !== "string" || typeof content !== "string") {
+      throw httpError(400, `messages[${i}] needs string "role" and "content"`);
+    }
+    return { role, content };
+  });
+}

--- a/src/tools/mcp.ts
+++ b/src/tools/mcp.ts
@@ -46,7 +46,3 @@ export async function loadMcpTools(configPath?: string): Promise<McpLoadResult> 
   _cached = { tools, client };
   return _cached;
 }
-
-export function getMcpTools(): DynamicStructuredTool[] {
-  return _cached?.tools ?? [];
-}

--- a/tests/server/validation.test.ts
+++ b/tests/server/validation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { httpError, validateMessages } from "../../src/server/validation";
+
+/**
+ * Regression tests for the request-validation helpers in the HTTP server.
+ * These mirror the exported logic without booting Fastify or an LLM.
+ *
+ * Before these fixes: an unknown app returned 500 (not 404), and a malformed
+ * body like `{"messages": "hi"}` returned 200 — LangChain coerced the string
+ * into a message and ran the agent on it.
+ */
+
+describe("validateMessages", () => {
+  it("accepts a well-formed messages array", () => {
+    expect(validateMessages([{ role: "user", content: "hi" }])).toEqual([
+      { role: "user", content: "hi" },
+    ]);
+  });
+
+  it("treats a missing messages field as empty", () => {
+    expect(validateMessages(undefined)).toEqual([]);
+  });
+
+  it("rejects a string instead of an array with 400", () => {
+    try {
+      validateMessages("not-an-array");
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect((err as { statusCode: number }).statusCode).toBe(400);
+      expect((err as Error).message).toContain("must be an array");
+    }
+  });
+
+  it("rejects a message missing content with 400", () => {
+    try {
+      validateMessages([{ role: "user" }]);
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect((err as { statusCode: number }).statusCode).toBe(400);
+      expect((err as Error).message).toContain('needs string "role" and "content"');
+    }
+  });
+
+  it("rejects a non-object entry with 400", () => {
+    try {
+      validateMessages(["hello"]);
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect((err as { statusCode: number }).statusCode).toBe(400);
+    }
+  });
+});
+
+describe("httpError", () => {
+  it("carries a status the Fastify error handler reads", () => {
+    const err = httpError(404, 'Unknown app: "nope"');
+    expect(err.statusCode).toBe(404);
+    expect(err.message).toContain("nope");
+  });
+});


### PR DESCRIPTION
## What

Fixes six verified bugs — three that break the advertised experience for new users, plus server hardening and dead code left over from the v2 migration.

| Bug | Before | After |
|---|---|---|
| Scaffolded `npm run dev:http` | `ERR_MODULE_NOT_FOUND` | Server boots, `/health` responds |
| Scaffolded `npm test` | exit 1, "No test files found" | exit 0, tests pass |
| RAG graph in LangGraph Studio | `Cannot read properties of undefined (reading 'search')` | Self-initializes, retrieval works |
| Unknown app over HTTP | `500` | `404` |
| `{"messages":"hi"}` | `200` — agent ran on coerced garbage | `400` with a clear error |
| `SIGTERM` | no handler, abrupt kill | drains, then "Shutdown complete." |

## Why

The first two hit **every** `npx create-langgraph-app` user: the generator never emitted `src/server.ts` even though `package.json` declared `"dev:http": "tsx src/server.ts"` (and shipped `fastify` as an unused dependency), and it generated zero test files while declaring a `test` script, so `vitest` exited 1 on a fresh project. Both shipped in 1.1.0 and 1.2.0.

The third is subtler: `langgraph.json` registers `createRagApp`, but it required a `vectorStore` argument Studio cannot supply. The graph *loads* fine and only throws on the first retrieval — so it looks healthy right up until someone asks it a question.

The rest is hardening: input validation (a malformed body silently became a `HumanMessage` and ran the agent), correct status codes, and `SIGTERM`/`SIGINT` handling — the Dockerfile runs node as PID 1, so `docker stop` was killing in-flight requests and skipping the `onClose` hook that closes the MCP client.

`getStore()` was orphaned by the v2 migration; since `createAgent` accepts a `store`, it's wired back through `makeAgent`/`makeSupervisor`/`makeSwarm` rather than deleted, restoring the cross-thread store the pre-migration code compiled with. `getMcpTools()` had no callers and is removed.

## How to test

- [x] `npm test` passes — 45 tests (up from 39), including new unit tests for the validation helpers
- [x] `npm run typecheck` passes
- [x] Passes with `.env` removed (CI-equivalent — the agent tests must not need API keys)
- [x] Scaffolded a project with 4 patterns: typechecks, tests pass, server boots and routes only the selected patterns
- [x] Verified live against Ollama — both the kit and a freshly scaffolded project answer a real request end-to-end (`add 3 and 4` → `7` through the full supervisor→subagent→tool chain), return 404/400 correctly, and exit cleanly on `SIGTERM`

### Notes for review

- The validation helpers live in `src/server/validation.ts` rather than inline, so the tests import the shipped code instead of a copy. Mutation-checked: breaking the real implementation fails the test.
- Docs updated (`README.md`, `docs/BUILDING.md`) for the `store` parameter and the new server behavior.
- Versions: kit `2.0.0` → `2.1.0`, CLI `1.2.0` → `1.3.0`. Publishing the scaffolder fixes to npm needs a separate `cli-v1.3.0` tag.
