### PR TITLE
fix: isolate RAG embeddings failures from the rest of the kit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,13 @@
 # LLM Provider: openai | anthropic | google | groq | ollama
 LLM_PROVIDER=openai
 
-# API keys (only the one matching your provider is required)
+# API keys (the one matching your provider is required)
+#
+# NOTE: the RAG pattern also needs an embeddings provider. Anthropic and Groq
+# have none, so they fall back to OpenAI embeddings — using RAG with those
+# providers additionally requires OPENAI_API_KEY. OpenAI, Google and Ollama
+# supply their own. Without it the RAG demo/route is skipped; everything else
+# still runs.
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GOOGLE_API_KEY=

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -276,6 +276,18 @@ Beyond the routes listed in the README, `src/server/index.ts` handles:
   client. Container runtimes (Docker, Railway, Render) send `SIGTERM` on stop,
   so without this the process would die mid-request.
 
+## RAG and embeddings
+
+RAG needs an embeddings model, which is a separate capability from chat.
+`src/config/embeddings.ts` maps each provider to one; **Anthropic and Groq have
+no embeddings API**, so they fall back to OpenAI's — meaning RAG with those
+providers also requires `OPENAI_API_KEY`, even though `assertProviderKey()`
+only validates the chat provider's key.
+
+This failure is isolated: the CLI demo builds the RAG app inside its `runDemo`
+wrapper, and the server registers `/rag` only if embeddings initialize. A
+missing embeddings key costs you the RAG app, not the whole process.
+
 ## Testing without an API key
 
 `tests/helpers/scripted-model.ts` provides `ScriptedToolCallingModel` — a fake

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { createSupervisorApp } from "./apps/supervisor";
 import { createInterruptApp } from "./apps/interrupt";
 import { createAnalystApp } from "./apps/analyst";
 import { createResearcherApp } from "./apps/researcher";
-import { createRagApp, initRagStore } from "./apps/rag";
+import { createRagApp } from "./apps/rag";
 import { createSupportApp } from "./apps/support";
 
 function lastContent(messages: BaseMessage[]): string {
@@ -40,8 +40,6 @@ async function run(): Promise<void> {
   const analystApp = await createAnalystApp();
   const researcherApp = await createResearcherApp();
   const supportApp = await createSupportApp();
-  const ragStore = await initRagStore();
-  const ragApp = await createRagApp(ragStore);
 
   // -- Supervisor --
   await runDemo("Supervisor Demo", async () => {
@@ -77,7 +75,11 @@ async function run(): Promise<void> {
   });
 
   // -- RAG --
+  // Built inside runDemo: RAG needs an embeddings provider, and providers
+  // without one (anthropic, groq, deepseek) fall back to OpenAI. If that key
+  // is missing this must fail as a single demo, not take down the whole run.
   await runDemo("RAG Demo", async () => {
+    const ragApp = await createRagApp();
     const result = await ragApp.invoke(
       {
         messages: [{

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,7 +7,7 @@ import { createSupervisorApp } from "../apps/supervisor";
 import { createInterruptApp } from "../apps/interrupt";
 import { createAnalystApp } from "../apps/analyst";
 import { createResearcherApp } from "../apps/researcher";
-import { createRagApp, initRagStore } from "../apps/rag";
+import { createRagApp } from "../apps/rag";
 import { createSupportApp } from "../apps/support";
 import { loadMcpTools } from "../tools/mcp";
 import { httpError, validateMessages } from "./validation";
@@ -87,8 +87,17 @@ export async function startServer(): Promise<void> {
   // Load MCP tools first — they get injected into agents
   const { tools: mcpTools, client: mcpClient } = await loadMcpTools();
 
-  // Initialize RAG vector store (async — must complete before building apps)
-  const ragStore = await initRagStore();
+  // RAG needs an embeddings provider. Providers without one (anthropic, groq,
+  // deepseek) fall back to OpenAI, so a missing OPENAI_API_KEY must not stop
+  // the whole server from starting — register the other apps and skip /rag.
+  let ragApp: AppGraph | undefined;
+  try {
+    ragApp = asApp(await createRagApp());
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`RAG app unavailable (embeddings failed): ${msg}`);
+    console.warn("  /rag routes are disabled. Set OPENAI_API_KEY, or use a provider with its own embeddings.");
+  }
 
   // Build apps with MCP tools available
   const apps = {
@@ -97,9 +106,9 @@ export async function startServer(): Promise<void> {
     interrupt: asApp(await createInterruptApp()),
     analyst: asApp(await createAnalystApp()),
     researcher: asApp(await createResearcherApp()),
-    rag: asApp(await createRagApp(ragStore)),
     support: asApp(await createSupportApp()),
-  };
+    ...(ragApp ? { rag: ragApp } : {}),
+  } as Record<string, AppGraph>;
 
   type AppName = keyof typeof apps;
 


### PR DESCRIPTION
## What

RAG needs an embeddings model, which is a separate capability from chat. Providers without one — **Anthropic and Groq** (and DeepSeek, once #1 lands) — fall back to OpenAI embeddings. But `assertProviderKey()` only validates the *chat* provider's key, so the embeddings call could fail somewhere nothing caught it:

- `src/index.ts` built the RAG store **before** the `runDemo` loop, so the process died before *any* of the 7 demos ran.
- `src/server/index.ts` awaited it during startup, so the entire server failed to boot over one unavailable app.

Now the RAG app is built inside its own `runDemo` wrapper, and the server registers `/rag` only if embeddings initialize — logging why when they don't.

## Why

Measured with `LLM_PROVIDER=groq` and no `OPENAI_API_KEY`:

| | Before | After |
|---|---|---|
| `npm run dev` | died before demo 1 — **0 of 7 ran** | **7 of 7 run**; RAG reports its own failure |
| `npm run dev:http` | server would not boot | boots with 6 apps, logs why `/rag` is off |
| `POST /rag/invoke` | n/a (no server) | `404` listing the apps that are available |

One misconfigured optional feature shouldn't take down six working ones.

`.env.example` also claimed *"only the one matching your provider is required"*, which was untrue for two of five providers. Corrected there and documented in `docs/BUILDING.md`.

## How to test

- [x] `npm test` — 45 tests pass
- [x] `npm run typecheck` passes
- [x] Passes with `.env` removed (CI-equivalent)

Verified against real providers:

- [x] **Ollama** (`qwen3:4b` + `nomic-embed-text`) — RAG indexes 9 chunks, calls the retrieval tool, and answers from the knowledge base. No regression to the happy path.
- [x] **OpenAI** (valid key, exhausted credits) — 7/7 demos run, RAG fails alone with a clear 429.
- [x] **Anthropic** (via the OpenAI embeddings fallback) — 7/7 demos run; server boots with 6 apps and skips `/rag`.
- [x] **Groq** (no embeddings API) — same graceful degradation.
- [x] Sanity check: with embeddings available, `/health` lists all 7 apps including `rag`, exactly as before.

### Note

This is the pre-existing gap raised while reviewing #1. It affects Anthropic and Groq today, so it's fixed here on `main` rather than in that PR — which keeps the DeepSeek contribution scoped to adding a provider.
