### PR TITLE
feat: add EMBEDDINGS_PROVIDER to decouple chat and embeddings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,17 +2,20 @@
 LLM_PROVIDER=openai
 
 # API keys (the one matching your provider is required)
-#
-# NOTE: the RAG pattern also needs an embeddings provider. Anthropic, Groq and
-# DeepSeek have none, so they fall back to OpenAI embeddings — using RAG with those
-# providers additionally requires OPENAI_API_KEY. OpenAI, Google and Ollama
-# supply their own. Without it the RAG demo/route is skipped; everything else
-# still runs.
 OPENAI_API_KEY=
 ANTHROPIC_API_KEY=
 GOOGLE_API_KEY=
 GROQ_API_KEY=
 DEEPSEEK_API_KEY=
+
+# Embeddings (RAG only — optional)
+# Defaults from LLM_PROVIDER; anthropic/groq/deepseek fall back to openai.
+# Supported: openai | google | ollama
+# EMBEDDINGS_PROVIDER=openai
+# EMBEDDINGS_MODEL=text-embedding-3-small
+# NOTE: RAG needs an embeddings key. Without it the RAG demo/route is skipped
+# and everything else still runs. Set EMBEDDINGS_PROVIDER=ollama to run RAG
+# without OPENAI_API_KEY.
 
 # Model override (optional — sensible defaults per provider)
 # LLM_MODEL=gpt-4o-mini

--- a/.env.example
+++ b/.env.example
@@ -12,10 +12,10 @@ DEEPSEEK_API_KEY=
 # Defaults from LLM_PROVIDER; anthropic/groq/deepseek fall back to openai.
 # Supported: openai | google | ollama
 # EMBEDDINGS_PROVIDER=openai
-# EMBEDDINGS_MODEL=text-embedding-3-small
 # NOTE: RAG needs an embeddings key. Without it the RAG demo/route is skipped
 # and everything else still runs. Set EMBEDDINGS_PROVIDER=ollama to run RAG
 # without OPENAI_API_KEY.
+# EMBEDDINGS_MODEL=text-embedding-3-small  # openai example
 
 # Model override (optional — sensible defaults per provider)
 # LLM_MODEL=gpt-4o-mini

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ curl -X POST http://localhost:3000/researcher/invoke \
 
 In-memory vector store with semantic search. Best for: **answering questions about your own documents/knowledge base**.
 
+Embeddings default from `LLM_PROVIDER`; set `EMBEDDINGS_PROVIDER=ollama` to run
+RAG without an OpenAI key (e.g. `LLM_PROVIDER=deepseek` + `EMBEDDINGS_PROVIDER=ollama`).
+
 ```bash
 curl -X POST http://localhost:3000/rag/invoke \
   -H "Content-Type: application/json" \

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -278,13 +278,28 @@ Beyond the routes listed in the README, `src/server/index.ts` handles:
 
 ## RAG and embeddings
 
-RAG needs an embeddings model, which is a separate capability from chat.
-`src/config/embeddings.ts` maps each provider to one; **Anthropic, Groq and
-DeepSeek have no embeddings API**, so they fall back to OpenAI's — meaning RAG with those
-providers also requires `OPENAI_API_KEY`, even though `assertProviderKey()`
-only validates the chat provider's key.
+Chat and embeddings are decoupled. `EMBEDDINGS_PROVIDER` (optional) chooses the
+embeddings backend — `openai`, `google`, or `ollama` — independently of
+`LLM_PROVIDER`. `EMBEDDINGS_MODEL` overrides the model name.
 
-This failure is isolated: the CLI demo builds the RAG app inside its `runDemo`
+When `EMBEDDINGS_PROVIDER` is unset it defaults from `LLM_PROVIDER`:
+
+| LLM_PROVIDER | default EMBEDDINGS_PROVIDER |
+|---|---|
+| openai | openai |
+| google | google |
+| ollama | ollama |
+| anthropic / groq / deepseek | openai |
+
+**Anthropic, Groq and DeepSeek have no embeddings API**, so their implicit
+default is OpenAI. That fallback is logged once, with a hint to set
+`EMBEDDINGS_PROVIDER`. An explicit `EMBEDDINGS_PROVIDER=deepseek` is invalid
+and errors at startup.
+
+The embeddings key is validated on demand inside `createEmbeddings()`, not at
+`env.ts` import time — non-RAG users never need an embeddings key.
+
+Failures stay isolated: the CLI demo builds the RAG app inside its `runDemo`
 wrapper, and the server registers `/rag` only if embeddings initialize. A
 missing embeddings key costs you the RAG app, not the whole process.
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -294,7 +294,7 @@ When `EMBEDDINGS_PROVIDER` is unset it defaults from `LLM_PROVIDER`:
 **Anthropic, Groq and DeepSeek have no embeddings API**, so their implicit
 default is OpenAI. That fallback is logged once, with a hint to set
 `EMBEDDINGS_PROVIDER`. An explicit `EMBEDDINGS_PROVIDER=deepseek` is invalid
-and errors at startup.
+and errors when embeddings are initialized (for example, when the RAG app starts).
 
 The embeddings key is validated on demand inside `createEmbeddings()`, not at
 `env.ts` import time — non-RAG users never need an embeddings key.

--- a/src/config/embeddings.ts
+++ b/src/config/embeddings.ts
@@ -1,18 +1,61 @@
 import type { Embeddings } from "@langchain/core/embeddings";
-import { LLM_PROVIDER } from "./env";
+import {
+  EMBEDDINGS_MODEL,
+  EMBEDDINGS_PROVIDER,
+  EMBEDDINGS_PROVIDER_EXPLICIT,
+  LLM_PROVIDER,
+  LLM_PROVIDERS_WITHOUT_EMBEDDINGS,
+  type EmbeddingsProvider,
+} from "./env";
 
-const DEFAULTS: Record<string, string> = {
+const DEFAULTS: Record<EmbeddingsProvider, string> = {
   openai: "text-embedding-3-small",
-  anthropic: "text-embedding-3-small", // Anthropic doesn't have embeddings; fallback to OpenAI
   google: "text-embedding-004",
-  groq: "text-embedding-3-small", // Groq doesn't have embeddings; fallback to OpenAI
   ollama: "nomic-embed-text",
-  deepseek: "text-embedding-3-small", // DeepSeek doesn't have embeddings; fallback to OpenAI
 };
 
+// Providers with a native embeddings API (and their required env keys).
+const EMBEDDINGS_API_KEYS: Record<EmbeddingsProvider, string> = {
+  openai: "OPENAI_API_KEY",
+  google: "GOOGLE_API_KEY",
+  ollama: "",
+};
+
+function assertEmbeddingsProviderKey(provider: EmbeddingsProvider): void {
+  const requiredKey = EMBEDDINGS_API_KEYS[provider];
+  if (requiredKey && !process.env[requiredKey]) {
+    throw new Error(
+      `${requiredKey} is required for embeddings provider "${provider}" but not set in .env`
+    );
+  }
+}
+
+let implicitFallbackLogged = false;
+
+function maybeLogImplicitFallback(model: string): void {
+  // Log once when an implicit OpenAI fallback engages; skip if already logged
+  // or if the user set EMBEDDINGS_PROVIDER explicitly.
+  if (
+    implicitFallbackLogged ||
+    EMBEDDINGS_PROVIDER_EXPLICIT ||
+    !LLM_PROVIDERS_WITHOUT_EMBEDDINGS.has(LLM_PROVIDER) ||
+    EMBEDDINGS_PROVIDER !== "openai"
+  ) {
+    return;
+  }
+  console.warn(
+    `Embeddings: ${LLM_PROVIDER} has no embeddings API — falling back to OpenAI (${model}). ` +
+      `Set EMBEDDINGS_PROVIDER to choose explicitly.`
+  );
+  implicitFallbackLogged = true;
+}
+
 export async function createEmbeddings(modelOverride?: string): Promise<Embeddings> {
-  const provider = LLM_PROVIDER;
-  const model = modelOverride ?? DEFAULTS[provider] ?? DEFAULTS.openai;
+  const provider = EMBEDDINGS_PROVIDER;
+
+  const model = modelOverride ?? EMBEDDINGS_MODEL ?? DEFAULTS[provider];
+  maybeLogImplicitFallback(model);
+  assertEmbeddingsProviderKey(provider);
 
   switch (provider) {
     case "google": {
@@ -23,8 +66,7 @@ export async function createEmbeddings(modelOverride?: string): Promise<Embeddin
       const { OllamaEmbeddings } = await import("@langchain/ollama");
       return new OllamaEmbeddings({ model });
     }
-    default: {
-      // OpenAI embeddings as default (also used by anthropic/groq which lack embeddings)
+    case "openai": {
       const { OpenAIEmbeddings } = await import("@langchain/openai");
       return new OpenAIEmbeddings({ model });
     }

--- a/src/config/embeddings.ts
+++ b/src/config/embeddings.ts
@@ -1,10 +1,10 @@
 import type { Embeddings } from "@langchain/core/embeddings";
 import {
+  DEFAULT_EMBEDDINGS_PROVIDER,
   EMBEDDINGS_MODEL,
-  EMBEDDINGS_PROVIDER,
-  EMBEDDINGS_PROVIDER_EXPLICIT,
+  EMBEDDINGS_PROVIDER_RAW,
   LLM_PROVIDER,
-  LLM_PROVIDERS_WITHOUT_EMBEDDINGS,
+  VALID_EMBEDDINGS_PROVIDERS,
   type EmbeddingsProvider,
 } from "./env";
 
@@ -21,6 +21,22 @@ const EMBEDDINGS_API_KEYS: Record<EmbeddingsProvider, string> = {
   ollama: "",
 };
 
+function resolveEmbeddingsProviderAtCall(): { provider: EmbeddingsProvider; explicit: boolean } {
+  const explicit = Boolean(EMBEDDINGS_PROVIDER_RAW);
+  if (!EMBEDDINGS_PROVIDER_RAW) {
+    return { provider: DEFAULT_EMBEDDINGS_PROVIDER[LLM_PROVIDER], explicit: false };
+  }
+
+  const normalized = EMBEDDINGS_PROVIDER_RAW.toLowerCase();
+  if (!VALID_EMBEDDINGS_PROVIDERS.includes(normalized as EmbeddingsProvider)) {
+    throw new Error(
+      `Invalid EMBEDDINGS_PROVIDER "${EMBEDDINGS_PROVIDER_RAW}". Must be one of: ${VALID_EMBEDDINGS_PROVIDERS.join(", ")}`
+    );
+  }
+
+  return { provider: normalized as EmbeddingsProvider, explicit };
+}
+
 function assertEmbeddingsProviderKey(provider: EmbeddingsProvider): void {
   const requiredKey = EMBEDDINGS_API_KEYS[provider];
   if (requiredKey && !process.env[requiredKey]) {
@@ -32,29 +48,32 @@ function assertEmbeddingsProviderKey(provider: EmbeddingsProvider): void {
 
 let implicitFallbackLogged = false;
 
-function maybeLogImplicitFallback(model: string): void {
-  // Log once when an implicit OpenAI fallback engages; skip if already logged
-  // or if the user set EMBEDDINGS_PROVIDER explicitly.
+function maybeLogImplicitFallback(
+  provider: EmbeddingsProvider,
+  explicit: boolean,
+  model: string
+): void {
   if (
     implicitFallbackLogged ||
-    EMBEDDINGS_PROVIDER_EXPLICIT ||
-    !LLM_PROVIDERS_WITHOUT_EMBEDDINGS.has(LLM_PROVIDER) ||
-    EMBEDDINGS_PROVIDER !== "openai"
+    explicit ||
+    provider !== "openai" ||
+    DEFAULT_EMBEDDINGS_PROVIDER[LLM_PROVIDER] === LLM_PROVIDER
   ) {
     return;
   }
+
   console.warn(
     `Embeddings: ${LLM_PROVIDER} has no embeddings API — falling back to OpenAI (${model}). ` +
-      `Set EMBEDDINGS_PROVIDER to choose explicitly.`
+      "Set EMBEDDINGS_PROVIDER to choose explicitly."
   );
   implicitFallbackLogged = true;
 }
 
 export async function createEmbeddings(modelOverride?: string): Promise<Embeddings> {
-  const provider = EMBEDDINGS_PROVIDER;
+  const { provider, explicit } = resolveEmbeddingsProviderAtCall();
 
   const model = modelOverride ?? EMBEDDINGS_MODEL ?? DEFAULTS[provider];
-  maybeLogImplicitFallback(model);
+  maybeLogImplicitFallback(provider, explicit, model);
   assertEmbeddingsProviderKey(provider);
 
   switch (provider) {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -36,10 +36,51 @@ export function assertProviderKey(provider: LlmProvider): void {
   }
 }
 
+const VALID_EMBEDDINGS_PROVIDERS = ["openai", "google", "ollama"] as const;
+export type EmbeddingsProvider = (typeof VALID_EMBEDDINGS_PROVIDERS)[number];
+
+
+const DEFAULT_EMBEDDINGS_PROVIDER: Record<LlmProvider, EmbeddingsProvider> = {
+  openai: "openai",
+  anthropic: "openai", // Anthropic has no native embeddings API; fall back to OpenAI
+  google: "google",
+  groq: "openai",
+  ollama: "ollama",
+  deepseek: "openai",
+};
+
+/** Chat providers with no native embeddings API — implicit default falls back to OpenAI. */
+export const LLM_PROVIDERS_WITHOUT_EMBEDDINGS: ReadonlySet<LlmProvider> = new Set([
+  "anthropic",
+  "groq",
+  "deepseek",
+]);
+
+function resolveEmbeddingsProvider(llmProvider: LlmProvider): EmbeddingsProvider {
+  // step 1: Check environment variables(Prioritize explicitly configured by the user)
+  const explicit = process.env.EMBEDDINGS_PROVIDER?.trim().toLowerCase();
+  // step 2: If no, default mapping
+  if (!explicit) {
+    return DEFAULT_EMBEDDINGS_PROVIDER[llmProvider];
+  }
+  // step 3: After setting the environment variables, verify the legality first.
+  if (!VALID_EMBEDDINGS_PROVIDERS.includes(explicit as EmbeddingsProvider)) {
+    throw new Error(
+      `Invalid EMBEDDINGS_PROVIDER "${explicit}". Must be one of: ${VALID_EMBEDDINGS_PROVIDERS.join(", ")}`
+    );
+  }
+  // step 4: return value
+  return explicit as EmbeddingsProvider;
+}
+
 export const LLM_PROVIDER = resolveProvider();
 
 // Fail fast: validate the default provider's key at startup.
 assertProviderKey(LLM_PROVIDER);
+
+export const EMBEDDINGS_PROVIDER = resolveEmbeddingsProvider(LLM_PROVIDER);
+export const EMBEDDINGS_MODEL = process.env.EMBEDDINGS_MODEL || undefined;
+export const EMBEDDINGS_PROVIDER_EXPLICIT = Boolean(process.env.EMBEDDINGS_PROVIDER?.trim());
 
 export const LLM_MODEL = process.env.LLM_MODEL || undefined;
 export const LLM_TEMPERATURE = Number(process.env.LLM_TEMPERATURE ?? 0);

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -36,51 +36,27 @@ export function assertProviderKey(provider: LlmProvider): void {
   }
 }
 
-const VALID_EMBEDDINGS_PROVIDERS = ["openai", "google", "ollama"] as const;
+export const VALID_EMBEDDINGS_PROVIDERS = ["openai", "google", "ollama"] as const;
 export type EmbeddingsProvider = (typeof VALID_EMBEDDINGS_PROVIDERS)[number];
 
-
-const DEFAULT_EMBEDDINGS_PROVIDER: Record<LlmProvider, EmbeddingsProvider> = {
+export const DEFAULT_EMBEDDINGS_PROVIDER: Record<LlmProvider, EmbeddingsProvider> = {
   openai: "openai",
-  anthropic: "openai", // Anthropic has no native embeddings API; fall back to OpenAI
+  anthropic: "openai", // Anthropic has no native embeddings API; fall back to OpenAI.
   google: "google",
   groq: "openai",
   ollama: "ollama",
   deepseek: "openai",
 };
 
-/** Chat providers with no native embeddings API — implicit default falls back to OpenAI. */
-export const LLM_PROVIDERS_WITHOUT_EMBEDDINGS: ReadonlySet<LlmProvider> = new Set([
-  "anthropic",
-  "groq",
-  "deepseek",
-]);
-
-function resolveEmbeddingsProvider(llmProvider: LlmProvider): EmbeddingsProvider {
-  // step 1: Check environment variables(Prioritize explicitly configured by the user)
-  const explicit = process.env.EMBEDDINGS_PROVIDER?.trim().toLowerCase();
-  // step 2: If no, default mapping
-  if (!explicit) {
-    return DEFAULT_EMBEDDINGS_PROVIDER[llmProvider];
-  }
-  // step 3: After setting the environment variables, verify the legality first.
-  if (!VALID_EMBEDDINGS_PROVIDERS.includes(explicit as EmbeddingsProvider)) {
-    throw new Error(
-      `Invalid EMBEDDINGS_PROVIDER "${explicit}". Must be one of: ${VALID_EMBEDDINGS_PROVIDERS.join(", ")}`
-    );
-  }
-  // step 4: return value
-  return explicit as EmbeddingsProvider;
-}
-
 export const LLM_PROVIDER = resolveProvider();
 
 // Fail fast: validate the default provider's key at startup.
 assertProviderKey(LLM_PROVIDER);
 
-export const EMBEDDINGS_PROVIDER = resolveEmbeddingsProvider(LLM_PROVIDER);
+// Keep raw input in env config; embeddings provider parsing/validation is
+// deferred to createEmbeddings() so non-RAG users are unaffected.
+export const EMBEDDINGS_PROVIDER_RAW = process.env.EMBEDDINGS_PROVIDER?.trim();
 export const EMBEDDINGS_MODEL = process.env.EMBEDDINGS_MODEL || undefined;
-export const EMBEDDINGS_PROVIDER_EXPLICIT = Boolean(process.env.EMBEDDINGS_PROVIDER?.trim());
 
 export const LLM_MODEL = process.env.LLM_MODEL || undefined;
 export const LLM_TEMPERATURE = Number(process.env.LLM_TEMPERATURE ?? 0);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -96,7 +96,7 @@ export async function startServer(): Promise<void> {
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(`RAG app unavailable (embeddings failed): ${msg}`);
-    console.warn("  /rag routes are disabled. Set OPENAI_API_KEY, or use a provider with its own embeddings.");
+    console.warn("  /rag routes are disabled. Set EMBEDDINGS_PROVIDER (and its API key), or fix the embeddings error above.");
   }
 
   // Build apps with MCP tools available

--- a/tests/config/embeddings.test.ts
+++ b/tests/config/embeddings.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("embeddings config", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("implicit fallback to OpenAI requires OPENAI_API_KEY", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubEnv("LLM_PROVIDER", "deepseek");
+    vi.stubEnv("DEEPSEEK_API_KEY", "test-deepseek-key");
+    vi.stubEnv("OPENAI_API_KEY", "");
+
+    const { createEmbeddings } = await import("../../src/config/embeddings");
+
+    await expect(createEmbeddings()).rejects.toThrow(/OPENAI_API_KEY/);
+  });
+
+  it("explicit ollama provider needs no OpenAI key", async () => {
+    vi.stubEnv("LLM_PROVIDER", "deepseek");
+    vi.stubEnv("DEEPSEEK_API_KEY", "test-deepseek-key");
+    vi.stubEnv("EMBEDDINGS_PROVIDER", "ollama");
+
+    const { createEmbeddings } = await import("../../src/config/embeddings");
+    const embeddings = await createEmbeddings();
+
+    expect(typeof embeddings.embedQuery).toBe("function");
+  });
+
+  it("throws on explicit invalid embeddings provider", async () => {
+    vi.stubEnv("LLM_PROVIDER", "deepseek");
+    vi.stubEnv("DEEPSEEK_API_KEY", "test-deepseek-key");
+    vi.stubEnv("EMBEDDINGS_PROVIDER", "deepseek");
+
+    await expect(import("../../src/config/env")).rejects.toThrow(
+      /Invalid EMBEDDINGS_PROVIDER/
+    );
+  });
+
+  it("defaults embeddings provider to openai for openai chat", async () => {
+    vi.stubEnv("LLM_PROVIDER", "openai");
+    vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
+
+    const env = await import("../../src/config/env");
+    expect(env.EMBEDDINGS_PROVIDER).toBe("openai");
+  });
+
+  it("accepts EMBEDDINGS_MODEL pass-through without error", async () => {
+    vi.stubEnv("LLM_PROVIDER", "openai");
+    vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
+    vi.stubEnv("EMBEDDINGS_MODEL", "custom-model");
+
+    const { createEmbeddings } = await import("../../src/config/embeddings");
+    const embeddings = await createEmbeddings();
+
+    expect(typeof embeddings.embedQuery).toBe("function");
+  });
+
+  it("does not validate embeddings key at env import time", async () => {
+    vi.stubEnv("LLM_PROVIDER", "deepseek");
+    vi.stubEnv("DEEPSEEK_API_KEY", "test-deepseek-key");
+    vi.stubEnv("OPENAI_API_KEY", "");
+
+    const env = await import("../../src/config/env");
+    expect(env.EMBEDDINGS_PROVIDER).toBe("openai");
+  });
+
+  it("logs implicit fallback once", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubEnv("LLM_PROVIDER", "deepseek");
+    vi.stubEnv("DEEPSEEK_API_KEY", "test-deepseek-key");
+    vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
+
+    const { createEmbeddings } = await import("../../src/config/embeddings");
+    await createEmbeddings();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("deepseek has no embeddings API")
+    );
+  });
+});

--- a/tests/config/embeddings.test.ts
+++ b/tests/config/embeddings.test.ts
@@ -11,7 +11,7 @@ describe("embeddings config", () => {
   });
 
   it("implicit fallback to OpenAI requires OPENAI_API_KEY", async () => {
-    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => { });
     vi.stubEnv("LLM_PROVIDER", "deepseek");
     vi.stubEnv("DEEPSEEK_API_KEY", "test-deepseek-key");
     vi.stubEnv("OPENAI_API_KEY", "");
@@ -25,6 +25,7 @@ describe("embeddings config", () => {
     vi.stubEnv("LLM_PROVIDER", "deepseek");
     vi.stubEnv("DEEPSEEK_API_KEY", "test-deepseek-key");
     vi.stubEnv("EMBEDDINGS_PROVIDER", "ollama");
+    vi.stubEnv("OPENAI_API_KEY", "");
 
     const { createEmbeddings } = await import("../../src/config/embeddings");
     const embeddings = await createEmbeddings();
@@ -32,22 +33,24 @@ describe("embeddings config", () => {
     expect(typeof embeddings.embedQuery).toBe("function");
   });
 
-  it("throws on explicit invalid embeddings provider", async () => {
-    vi.stubEnv("LLM_PROVIDER", "deepseek");
-    vi.stubEnv("DEEPSEEK_API_KEY", "test-deepseek-key");
+  it("throws on explicit invalid embeddings provider when embeddings are created", async () => {
+    vi.stubEnv("LLM_PROVIDER", "openai");
+    vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
     vi.stubEnv("EMBEDDINGS_PROVIDER", "deepseek");
 
-    await expect(import("../../src/config/env")).rejects.toThrow(
-      /Invalid EMBEDDINGS_PROVIDER/
-    );
+    const { createEmbeddings } = await import("../../src/config/embeddings");
+
+    await expect(createEmbeddings()).rejects.toThrow(/Invalid EMBEDDINGS_PROVIDER/);
   });
 
   it("defaults embeddings provider to openai for openai chat", async () => {
     vi.stubEnv("LLM_PROVIDER", "openai");
     vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
 
-    const env = await import("../../src/config/env");
-    expect(env.EMBEDDINGS_PROVIDER).toBe("openai");
+    const { createEmbeddings } = await import("../../src/config/embeddings");
+    const embeddings = await createEmbeddings();
+
+    expect(typeof embeddings.embedQuery).toBe("function");
   });
 
   it("accepts EMBEDDINGS_MODEL pass-through without error", async () => {
@@ -67,18 +70,20 @@ describe("embeddings config", () => {
     vi.stubEnv("OPENAI_API_KEY", "");
 
     const env = await import("../../src/config/env");
-    expect(env.EMBEDDINGS_PROVIDER).toBe("openai");
+    expect(env.EMBEDDINGS_PROVIDER_RAW).toBeUndefined();
   });
 
   it("logs implicit fallback once", async () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => { });
     vi.stubEnv("LLM_PROVIDER", "deepseek");
     vi.stubEnv("DEEPSEEK_API_KEY", "test-deepseek-key");
     vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
 
     const { createEmbeddings } = await import("../../src/config/embeddings");
     await createEmbeddings();
+    await createEmbeddings();
 
+    expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining("deepseek has no embeddings API")
     );

--- a/tests/config/env.test.ts
+++ b/tests/config/env.test.ts
@@ -56,6 +56,19 @@ describe("env config", () => {
     vi.unstubAllEnvs();
   });
 
+
+
+  it("does not throw on invalid EMBEDDINGS_PROVIDER at env import time", async () => {
+    vi.stubEnv("LLM_PROVIDER", "openai");
+    vi.stubEnv("OPENAI_API_KEY", "test-key");
+    vi.stubEnv("EMBEDDINGS_PROVIDER", "azure");
+
+    const env = await import("../../src/config/env");
+    expect(env.EMBEDDINGS_PROVIDER_RAW).toBe("azure");
+
+    vi.unstubAllEnvs();
+  });
+
   it("parses PORT and LLM_TEMPERATURE as numbers", async () => {
     vi.stubEnv("OPENAI_API_KEY", "test-key");
     vi.stubEnv("PORT", "8080");


### PR DESCRIPTION
Closes #4

## Summary
- Add `EMBEDDINGS_PROVIDER` and `EMBEDDINGS_MODEL` for RAG-only embeddings config
- Keep the default mapping; log once when the implicit OpenAI fallback engages
- Validate embeddings keys inside `createEmbeddings()` (not at `env.ts` import time)
- Preserve #3 behavior: `/rag` conditional + RAG inside `runDemo`
- Scaffolder unchanged (per maintainer feedback)
- `EMBEDDINGS_MODEL` is passed through, matching `LLM_MODEL`

## Test plan
- [x] `npm test` — 54 tests pass
- [x] `npm run typecheck` passes
- [x] Manual: `LLM_PROVIDER=deepseek` without `OPENAI_API_KEY` — RAG fails alone with fallback warn; other demos continue
- [x] Manual: `EMBEDDINGS_PROVIDER=ollama` — no OpenAI key required (RAG needs a running Ollama)