### PR TITLE
test(scaffolder): compile generated projects in CI

### DIFF
--- a/create-langgraph-app/create.ts
+++ b/create-langgraph-app/create.ts
@@ -5,6 +5,7 @@ import { stdin, stdout } from "node:process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { execSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -74,13 +75,13 @@ const PROVIDERS: Record<string, { envKey: string; defaultModel: string }> = {
   deepseek: { envKey: "DEEPSEEK_API_KEY", defaultModel: "deepseek-v4-flash" },
 };
 
-interface Config {
+export interface Config {
   name: string;
   provider: string;
   patterns: string[];
 }
 
-function generateEnv(config: Config): string {
+export function generateEnv(config: Config): string {
   const prov = PROVIDERS[config.provider];
   const lines = [
     `# LLM Provider`,
@@ -112,7 +113,7 @@ function generateEnv(config: Config): string {
   return lines.join("\n") + "\n";
 }
 
-function generatePackageJson(config: Config): string {
+export function generatePackageJson(config: Config): string {
   const deps: Record<string, string> = {
     "@langchain/core": "^1.2.3",
     "@langchain/langgraph": "^1.4.8",
@@ -164,7 +165,7 @@ function generatePackageJson(config: Config): string {
   return JSON.stringify(pkg, null, 2) + "\n";
 }
 
-function generateTsConfig(): string {
+export function generateTsConfig(): string {
   return JSON.stringify(
     {
       compilerOptions: {
@@ -664,7 +665,7 @@ ${supervisorTest}});
 }
 
 // Pattern-specific: only files for selected patterns are generated
-function getPatternFiles(
+export function getPatternFiles(
   config: Config
 ): { path: string; content: string }[] {
   const files: { path: string; content: string }[] = [];
@@ -1148,7 +1149,11 @@ Provider: ${provider}${RESET}
   }
 }
 
-main().catch((err) => {
-  console.error("Error:", err);
-  process.exit(1);
-});
+// Only run the interactive CLI when executed directly. Importing this module
+// (e.g. from the scaffolder tests) must not prompt.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error("Error:", err);
+    process.exit(1);
+  });
+}

--- a/tests/scaffolder/generated-project.test.ts
+++ b/tests/scaffolder/generated-project.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, afterAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  generateEnv,
+  generatePackageJson,
+  generateTsConfig,
+  getPatternFiles,
+  type Config,
+} from "../../create-langgraph-app/create";
+
+/**
+ * The scaffolder's own output is not covered by anything else: CI typechecks
+ * the kit, never a generated project. That gap shipped a broken `dev:http` in
+ * 1.1.0 and 1.2.0 (a script pointing at a file the generator never wrote), and
+ * the same class of bug — a generated file importing a module the generator
+ * doesn't emit — has recurred since.
+ *
+ * These tests generate a project and compile it with the real tsc.
+ *
+ * The generated project borrows the kit's node_modules, since every provider
+ * SDK it can ask for is already a kit dependency. That means these tests catch
+ * unresolvable *relative* imports between generated files — the recurring bug —
+ * but not a dependency missing from the generated package.json.
+ */
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const tmpDirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of tmpDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function scaffold(config: Config): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lgsk-scaffold-"));
+  tmpDirs.push(dir);
+
+  const files = [
+    { path: "package.json", content: generatePackageJson(config) },
+    { path: "tsconfig.json", content: generateTsConfig() },
+    { path: ".env", content: generateEnv(config) },
+    ...getPatternFiles(config),
+  ];
+  for (const file of files) {
+    const full = path.join(dir, file.path);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, file.content);
+  }
+
+  fs.symlinkSync(path.join(repoRoot, "node_modules"), path.join(dir, "node_modules"), "dir");
+  return dir;
+}
+
+/** Compile the generated project; returns tsc's output ("" when clean). */
+function typecheck(dir: string): string {
+  try {
+    execFileSync(path.join(repoRoot, "node_modules/.bin/tsc"), ["--noEmit"], {
+      cwd: dir,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return "";
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string };
+    return `${e.stdout ?? ""}${e.stderr ?? ""}`.trim();
+  }
+}
+
+const ALL_PATTERNS = ["supervisor", "swarm", "hitl", "structured", "rag"];
+
+describe("scaffolded projects compile", () => {
+  it("with every pattern selected", () => {
+    const dir = scaffold({ name: "all-app", provider: "openai", patterns: ALL_PATTERNS });
+    expect(typecheck(dir)).toBe("");
+  }, 120_000);
+
+  // Each pattern alone: a pattern can be broken in isolation while the
+  // combined project still compiles (e.g. its files are emitted by a sibling).
+  it.each(ALL_PATTERNS)("with only the %s pattern", (pattern) => {
+    const dir = scaffold({ name: `${pattern}-app`, provider: "openai", patterns: [pattern] });
+    expect(typecheck(dir)).toBe("");
+  }, 120_000);
+
+  it("emits every file its own imports reference", () => {
+    const dir = scaffold({ name: "imports-app", provider: "ollama", patterns: ALL_PATTERNS });
+    const written = new Set(
+      getPatternFiles({ name: "imports-app", provider: "ollama", patterns: ALL_PATTERNS })
+        .map((f) => f.path)
+    );
+
+    const missing: string[] = [];
+    for (const filePath of written) {
+      const src = fs.readFileSync(path.join(dir, filePath), "utf-8");
+      for (const m of src.matchAll(/from\s+"(\.[^"]+)"/g)) {
+        const target = path
+          .normalize(path.join(path.dirname(filePath), m[1]))
+          .replace(/\\/g, "/");
+        if (!written.has(`${target}.ts`)) missing.push(`${filePath} → ${m[1]}`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Generates projects with the scaffolder and compiles them with the real `tsc`, so a broken generator fails CI.

## Why

Nothing covered the scaffolder's output. CI typechecks *the kit*, never a project the generator produces — so `create-langgraph-app` can be thoroughly broken while every check stays green.

That gap already cost us two releases: **1.1.0 and 1.2.0** shipped with `"dev:http": "tsx src/server.ts"` in the generated `package.json` and no `src/server.ts` ever written. Every scaffolded project crashed on `npm run dev:http`, and `npm test` exited 1 with no test files (fixed in #2).

The shape recurs: a generated file references something the generator doesn't write. Cheap to catch, invisible to the current suite, and a change can pass both CI checks while breaking every scaffolded project.

## What it checks

- **All patterns selected** — compiles clean
- **Each pattern alone** — a pattern can break in isolation while the combined project still compiles, because a sibling emits the file it needs. This is what pinpoints *which* pattern regressed.
- **Every relative import resolves** to a file the generator actually emits — a static check that fails with a readable list rather than a wall of TS2307s

Validated by running it against a generator with these bugs deliberately present: 5 of 7 tests fail, naming each unresolvable import and identifying the specific patterns affected.

## Implementation note

Driving the interactive CLI in a test would need a PTY. Instead the pure generator functions are exported, and the interactive `main()` now runs only when `create.ts` is executed directly. Verified the published `dist/create.js` bin still prompts exactly as before.

## Known limit

The generated project symlinks the kit's `node_modules`, since every provider SDK it can request is already a kit dependency. So this catches unresolvable *relative* imports between generated files — the recurring bug — but **not** a dependency missing from the generated `package.json`. Worth stating so nobody assumes broader coverage than exists.

## How to test

- [x] `npm test` — 61 tests pass (up from 54), no `.env` present (CI-equivalent)
- [x] `npm run typecheck` clean
- [x] Scaffolder typechecks and builds
- [x] `node dist/create.js` still launches the interactive prompt
