### PR TITLE
feat(scaffolder): generate a working RAG implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ graph TD
 | **Observe** | LangSmith Tracing | Full observability with one env var |
 | **Persist** | Memory + Postgres | In-memory for dev, PostgreSQL-ready for production |
 | **Deploy** | Docker + CI | Docker Compose with Postgres, GitHub Actions CI |
-| **Test** | 45 Tests | Tools, config, agents, request validation, offline multi-agent flows — all with vitest |
+| **Test** | 61 Tests | Tools, config, agents, request validation, offline multi-agent flows, and generated-project compilation — all with vitest |
 
 ## Quick Start
 

--- a/create-langgraph-app/create.ts
+++ b/create-langgraph-app/create.ts
@@ -81,6 +81,23 @@ export interface Config {
   patterns: string[];
 }
 
+/**
+ * Extra .env lines when RAG borrows another provider's embeddings — that key is
+ * required too, which is not obvious from the chat provider alone.
+ */
+function embeddingsEnvLines(config: Config): string[] {
+  if (!config.patterns.includes("rag")) return [];
+  const e = embeddingsFor(config.provider);
+  if (!e.borrowed) return [];
+  return [
+    `# RAG embeddings: ${config.provider} has no embeddings API, so RAG uses ${e.id}`,
+    `# and needs this key in addition to your chat provider's.`,
+    `${e.envKey}=`,
+    `# EMBEDDINGS_MODEL=${e.defaultModel}`,
+    ``,
+  ];
+}
+
 export function generateEnv(config: Config): string {
   const prov = PROVIDERS[config.provider];
   const lines = [
@@ -100,16 +117,7 @@ export function generateEnv(config: Config): string {
     `# LLM_MODEL=${prov.defaultModel}`,
     `LLM_TEMPERATURE=0`,
     ``,
-    ...(config.patterns.includes("rag") &&
-    (EMBEDDINGS_FOR_PROVIDER[config.provider] ?? "openai") !== config.provider
-      ? [
-          `# RAG embeddings: ${config.provider} has no embeddings API, so RAG uses`,
-          `# ${EMBEDDINGS_FOR_PROVIDER[config.provider] ?? "openai"} and needs its key as well.`,
-          `${PROVIDER_EMBEDDINGS[EMBEDDINGS_FOR_PROVIDER[config.provider] ?? "openai"].envKey}=`,
-          `# EMBEDDINGS_MODEL=${PROVIDER_EMBEDDINGS[EMBEDDINGS_FOR_PROVIDER[config.provider] ?? "openai"].defaultModel}`,
-          ``,
-        ]
-      : []),
+    ...embeddingsEnvLines(config),
     ...(config.provider === "deepseek"
       ? [`# DeepSeek reasoning mode (optional — "disabled" | "enabled")`, `# DEEPSEEK_THINKING=disabled`, ``]
       : []),
@@ -152,8 +160,7 @@ export function generatePackageJson(config: Config): string {
   // RAG needs an embeddings SDK, which is a different package when the chat
   // provider has no embeddings API of its own (anthropic, groq, deepseek).
   if (config.patterns.includes("rag")) {
-    const embPkg = PROVIDER_EMBEDDINGS[EMBEDDINGS_FOR_PROVIDER[config.provider] ?? "openai"].pkg;
-    if (!deps[embPkg]) deps[embPkg] = "latest";
+    deps[embeddingsFor(config.provider).pkg] ??= "latest";
   }
 
   const pkg = {
@@ -257,17 +264,8 @@ const PROVIDER_LLM: Record<
   deepseek: { pkg: "@langchain/deepseek", className: "ChatDeepSeek", modelArg: "model", defaultModel: "deepseek-v4-flash", extraArgs: 'modelKwargs: { thinking: { type: DEEPSEEK_THINKING } }' },
 };
 
-// Which provider supplies embeddings for a given chat provider. Anthropic, Groq
-// and DeepSeek have no embeddings API, so they fall back to OpenAI's.
-const EMBEDDINGS_FOR_PROVIDER: Record<string, "openai" | "google" | "ollama"> = {
-  openai: "openai",
-  anthropic: "openai",
-  google: "google",
-  groq: "openai",
-  ollama: "ollama",
-  deepseek: "openai",
-};
-
+// Only these three have a native embeddings API. Anthropic, Groq and DeepSeek
+// have none, so RAG on those providers borrows OpenAI's.
 const PROVIDER_EMBEDDINGS: Record<
   string,
   { pkg: string; className: string; defaultModel: string; envKey: string }
@@ -277,6 +275,12 @@ const PROVIDER_EMBEDDINGS: Record<
   ollama: { pkg: "@langchain/ollama", className: "OllamaEmbeddings", defaultModel: "nomic-embed-text", envKey: "" },
 };
 
+/** Resolves which provider supplies embeddings for a given chat provider. */
+function embeddingsFor(chatProvider: string) {
+  const id = chatProvider in PROVIDER_EMBEDDINGS ? chatProvider : "openai";
+  return { id, borrowed: id !== chatProvider, ...PROVIDER_EMBEDDINGS[id] };
+}
+
 /**
  * The scaffold installs one embeddings SDK — the one for the provider resolved
  * at generation time — so the generated config imports only that SDK. Switching
@@ -284,20 +288,19 @@ const PROVIDER_EMBEDDINGS: Record<
  * branch here.
  */
 function generateEmbeddingsConfig(config: Config): string {
-  const providerId = EMBEDDINGS_FOR_PROVIDER[config.provider] ?? "openai";
-  const e = PROVIDER_EMBEDDINGS[providerId];
-  const fellBack = providerId !== config.provider;
+  const e = embeddingsFor(config.provider);
+  const borrowedNote = e.borrowed
+    ? `// ${config.provider} has no embeddings API, so RAG uses ${e.id} — it needs\n` +
+      `// ${e.envKey} in addition to your chat provider's key.\n`
+    : "";
 
   return `import type { Embeddings } from "@langchain/core/embeddings";
 import { ${e.className} } from "${e.pkg}";
 
-const PROVIDER = "${providerId}";
+${borrowedNote}// Set EMBEDDINGS_MODEL in .env to override the default model.
+const PROVIDER = "${e.id}";
 const DEFAULT_MODEL = "${e.defaultModel}";
-${e.envKey ? `const REQUIRED_KEY = "${e.envKey}";` : `const REQUIRED_KEY = "";`}
-${fellBack ? `
-// ${config.provider} has no embeddings API, so embeddings use ${providerId}.
-// That means RAG needs ${e.envKey} in addition to your chat provider's key.
-// Set EMBEDDINGS_MODEL to override the model.` : ""}
+const REQUIRED_KEY = "${e.envKey}";
 
 /**
  * Builds the embeddings client for RAG.
@@ -511,15 +514,17 @@ function selectedApps(config: Config) {
 function generateServer(config: Config): string {
   const apps = selectedApps(config);
   const imports = apps.map((a) => `import { ${a.fn} } from "${a.path}";`).join("\n");
+  // RAG is the only app that can fail at startup — it needs an embeddings
+  // provider, and providers without one borrow another provider's key. Build it
+  // in a try/catch so a missing key costs /rag rather than every route.
+  const hasRag = apps.some((a) => a.route === "rag");
+
   const entries = apps
     .filter((a) => a.route !== "rag")
     .map((a) => `    "${a.route}": asApp(await ${a.fn}()),`)
     .join("\n");
-
-  // RAG is the one app that can fail at startup: it needs an embeddings
-  // provider, and providers without one fall back to another provider's key.
-  // Build it in a try/catch so a missing key costs /rag, not every route.
-  const ragInit = apps.some((a) => a.route === "rag")
+  const ragEntry = hasRag ? `\n    ...(ragApp ? { rag: ragApp } : {}),` : "";
+  const ragInit = hasRag
     ? `  let ragApp: AppGraph | undefined;
   try {
     ragApp = asApp(await createRagApp());
@@ -530,9 +535,6 @@ function generateServer(config: Config): string {
   }
 
 `
-    : "";
-  const ragEntry = apps.some((a) => a.route === "rag")
-    ? `\n    ...(ragApp ? { rag: ragApp } : {}),`
     : "";
 
   return `import "./config/env";

--- a/create-langgraph-app/create.ts
+++ b/create-langgraph-app/create.ts
@@ -100,6 +100,16 @@ export function generateEnv(config: Config): string {
     `# LLM_MODEL=${prov.defaultModel}`,
     `LLM_TEMPERATURE=0`,
     ``,
+    ...(config.patterns.includes("rag") &&
+    (EMBEDDINGS_FOR_PROVIDER[config.provider] ?? "openai") !== config.provider
+      ? [
+          `# RAG embeddings: ${config.provider} has no embeddings API, so RAG uses`,
+          `# ${EMBEDDINGS_FOR_PROVIDER[config.provider] ?? "openai"} and needs its key as well.`,
+          `${PROVIDER_EMBEDDINGS[EMBEDDINGS_FOR_PROVIDER[config.provider] ?? "openai"].envKey}=`,
+          `# EMBEDDINGS_MODEL=${PROVIDER_EMBEDDINGS[EMBEDDINGS_FOR_PROVIDER[config.provider] ?? "openai"].defaultModel}`,
+          ``,
+        ]
+      : []),
     ...(config.provider === "deepseek"
       ? [`# DeepSeek reasoning mode (optional — "disabled" | "enabled")`, `# DEEPSEEK_THINKING=disabled`, ``]
       : []),
@@ -138,6 +148,13 @@ export function generatePackageJson(config: Config): string {
     deepseek: "@langchain/deepseek",
   };
   deps[provPkg[config.provider]] = "latest";
+
+  // RAG needs an embeddings SDK, which is a different package when the chat
+  // provider has no embeddings API of its own (anthropic, groq, deepseek).
+  if (config.patterns.includes("rag")) {
+    const embPkg = PROVIDER_EMBEDDINGS[EMBEDDINGS_FOR_PROVIDER[config.provider] ?? "openai"].pkg;
+    if (!deps[embPkg]) deps[embPkg] = "latest";
+  }
 
   const pkg = {
     name: config.name,
@@ -239,6 +256,74 @@ const PROVIDER_LLM: Record<
   ollama: { pkg: "@langchain/ollama", className: "ChatOllama", modelArg: "model", defaultModel: "llama3.2" },
   deepseek: { pkg: "@langchain/deepseek", className: "ChatDeepSeek", modelArg: "model", defaultModel: "deepseek-v4-flash", extraArgs: 'modelKwargs: { thinking: { type: DEEPSEEK_THINKING } }' },
 };
+
+// Which provider supplies embeddings for a given chat provider. Anthropic, Groq
+// and DeepSeek have no embeddings API, so they fall back to OpenAI's.
+const EMBEDDINGS_FOR_PROVIDER: Record<string, "openai" | "google" | "ollama"> = {
+  openai: "openai",
+  anthropic: "openai",
+  google: "google",
+  groq: "openai",
+  ollama: "ollama",
+  deepseek: "openai",
+};
+
+const PROVIDER_EMBEDDINGS: Record<
+  string,
+  { pkg: string; className: string; defaultModel: string; envKey: string }
+> = {
+  openai: { pkg: "@langchain/openai", className: "OpenAIEmbeddings", defaultModel: "text-embedding-3-small", envKey: "OPENAI_API_KEY" },
+  google: { pkg: "@langchain/google-genai", className: "GoogleGenerativeAIEmbeddings", defaultModel: "text-embedding-004", envKey: "GOOGLE_API_KEY" },
+  ollama: { pkg: "@langchain/ollama", className: "OllamaEmbeddings", defaultModel: "nomic-embed-text", envKey: "" },
+};
+
+/**
+ * The scaffold installs one embeddings SDK — the one for the provider resolved
+ * at generation time — so the generated config imports only that SDK. Switching
+ * EMBEDDINGS_PROVIDER later means installing the matching package and adding a
+ * branch here.
+ */
+function generateEmbeddingsConfig(config: Config): string {
+  const providerId = EMBEDDINGS_FOR_PROVIDER[config.provider] ?? "openai";
+  const e = PROVIDER_EMBEDDINGS[providerId];
+  const fellBack = providerId !== config.provider;
+
+  return `import type { Embeddings } from "@langchain/core/embeddings";
+import { ${e.className} } from "${e.pkg}";
+
+const PROVIDER = "${providerId}";
+const DEFAULT_MODEL = "${e.defaultModel}";
+${e.envKey ? `const REQUIRED_KEY = "${e.envKey}";` : `const REQUIRED_KEY = "";`}
+${fellBack ? `
+// ${config.provider} has no embeddings API, so embeddings use ${providerId}.
+// That means RAG needs ${e.envKey} in addition to your chat provider's key.
+// Set EMBEDDINGS_MODEL to override the model.` : ""}
+
+/**
+ * Builds the embeddings client for RAG.
+ *
+ * Validation happens here rather than at import time: a project that never uses
+ * RAG should not need an embeddings key, and an eager throw would take down
+ * every route rather than just the RAG one.
+ */
+export async function createEmbeddings(modelOverride?: string): Promise<Embeddings> {
+  const requested = process.env.EMBEDDINGS_PROVIDER?.trim().toLowerCase();
+  if (requested && requested !== PROVIDER) {
+    throw new Error(
+      \`EMBEDDINGS_PROVIDER="\${requested}" but this project was scaffolded with "\${PROVIDER}" embeddings. \` +
+        \`Install the matching SDK and add a branch in src/config/embeddings.ts.\`
+    );
+  }
+
+  if (REQUIRED_KEY && !process.env[REQUIRED_KEY]) {
+    throw new Error(\`\${REQUIRED_KEY} is required for "\${PROVIDER}" embeddings but is not set in .env\`);
+  }
+
+  const model = modelOverride ?? process.env.EMBEDDINGS_MODEL?.trim() ?? DEFAULT_MODEL;
+  return new ${e.className}({ model });
+}
+`;
+}
 
 function generateLlmConfig(config: Config): string {
   const p = PROVIDER_LLM[config.provider] ?? PROVIDER_LLM.openai;
@@ -1015,21 +1100,129 @@ export async function createAnalystApp() {
   }
 
   if (config.patterns.includes("rag")) {
+    files.push({ path: "src/config/embeddings.ts", content: generateEmbeddingsConfig(config) });
+    files.push({
+      path: "src/tools/rag.ts",
+      content: `import { z } from "zod";
+import { tool } from "@langchain/core/tools";
+import type { Embeddings } from "@langchain/core/embeddings";
+import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
+
+/** In-memory vector store — no external database required. */
+export interface InMemoryVectorStore {
+  size: number;
+  search: (query: string, k?: number) => Promise<string[]>;
+}
+
+interface Chunk {
+  content: string;
+  embedding: number[];
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+  let dot = 0, normA = 0, normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  // Guard the zero vector: without this an empty embedding yields NaN and
+  // silently corrupts the ranking.
+  return normA === 0 || normB === 0 ? 0 : dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+export async function buildVectorStore(
+  embeddings: Embeddings,
+  documents: string[],
+  chunkSize = 500,
+  chunkOverlap = 100,
+): Promise<InMemoryVectorStore> {
+  const splitter = new RecursiveCharacterTextSplitter({ chunkSize, chunkOverlap });
+  const docs = await splitter.createDocuments(documents);
+  const texts = docs.map((d) => d.pageContent);
+  const vectors = await embeddings.embedDocuments(texts);
+  const chunks: Chunk[] = texts.map((content, i) => ({ content, embedding: vectors[i] }));
+
+  return {
+    size: chunks.length,
+    search: async (query: string, k = 4) => {
+      if (chunks.length === 0) return [];
+      const queryVector = await embeddings.embedQuery(query);
+      return chunks
+        .map((c) => ({ content: c.content, score: cosineSimilarity(queryVector, c.embedding) }))
+        .sort((a, b) => b.score - a.score)
+        .slice(0, k)
+        .map((c) => c.content);
+    },
+  };
+}
+
+export function createRetrievalTool(vectorStore: InMemoryVectorStore) {
+  return tool(
+    async ({ query, k }) => {
+      const results = await vectorStore.search(query, k);
+      if (results.length === 0) return "No relevant documents found. Try rephrasing.";
+      return results.map((r, i) => "[" + (i + 1) + "] " + r).join("\\n\\n");
+    },
+    {
+      name: "search_knowledge_base",
+      description:
+        "Search the knowledge base for relevant information. Use this to find context before answering.",
+      schema: z.object({
+        query: z.string().describe("The search query"),
+        k: z.number().optional().default(4).describe("Number of results to return"),
+      }),
+    }
+  );
+}
+
+/** Replace these with your own documents. */
+export const SAMPLE_DOCS = [
+  "LangGraph is a framework for building stateful, multi-actor applications with LLMs. It uses a graph architecture where nodes are computational steps and edges define the flow between them. Key features include persistence via checkpointing, streaming, and human-in-the-loop workflows.",
+  "The supervisor pattern uses a central coordinator that routes tasks to specialized worker agents and aggregates their results. Workers are stateless and run in isolated context windows, so the supervisor only sees each worker's final answer.",
+  "The swarm pattern lets peer agents hand off control to each other with transfer tools. Each agent is a graph node, and the active agent persists across turns, so a conversation resumes with whichever agent last held it.",
+];
+`,
+    });
     files.push({
       path: "src/apps/rag.ts",
       content: `import { MemorySaver } from "@langchain/langgraph";
 import { getLlm } from "../config/llm";
+import { createEmbeddings } from "../config/embeddings";
 import { makeAgent } from "../agents/factory";
-// TODO: Add your vector store, embeddings, and retrieval tool here.
-// See the full starter kit for a complete RAG implementation:
-// https://github.com/ac12644/langgraph-starter-kit
+import {
+  buildVectorStore,
+  createRetrievalTool,
+  SAMPLE_DOCS,
+  type InMemoryVectorStore,
+} from "../tools/rag";
 
-export async function createRagApp() {
+let _vectorStore: InMemoryVectorStore | null = null;
+
+/** Indexes the documents once; later calls reuse the same store. */
+export async function initRagStore(documents: string[] = SAMPLE_DOCS): Promise<InMemoryVectorStore> {
+  if (!_vectorStore) {
+    const embeddings = await createEmbeddings();
+    _vectorStore = await buildVectorStore(embeddings, documents);
+    console.log("RAG: indexed " + _vectorStore.size + " chunks");
+  }
+  return _vectorStore;
+}
+
+export async function createRagApp(vectorStore?: InMemoryVectorStore) {
   const llm = await getLlm();
+  const retrievalTool = createRetrievalTool(vectorStore ?? (await initRagStore()));
 
   return makeAgent({
-    name: "rag_agent", llm, tools: [],
-    system: "You are a knowledgeable assistant. Answer questions based on your knowledge.",
+    name: "rag_agent",
+    llm,
+    tools: [retrievalTool],
+    system: [
+      "You are a knowledgeable assistant with access to a knowledge base.",
+      "ALWAYS search the knowledge base before answering questions.",
+      "Base your answers on the retrieved documents. If they do not contain",
+      "the answer, say so clearly rather than guessing.",
+    ].join("\\n"),
     checkpointer: new MemorySaver(),
   });
 }
@@ -1039,7 +1232,7 @@ export async function createRagApp() {
     demos.push(`  console.log("\\n=== RAG Demo ===");
   const ragApp = await createRagApp();
   const rag = await ragApp.invoke(
-    { messages: [{ role: "user", content: "What is RAG and how does it work?" }] },
+    { messages: [{ role: "user", content: "What is the supervisor pattern?" }] },
     { configurable: { thread_id: "rag-demo" } }
   );
   console.log("Result:", rag.messages.at(-1)?.content);`);

--- a/create-langgraph-app/create.ts
+++ b/create-langgraph-app/create.ts
@@ -511,7 +511,29 @@ function selectedApps(config: Config) {
 function generateServer(config: Config): string {
   const apps = selectedApps(config);
   const imports = apps.map((a) => `import { ${a.fn} } from "${a.path}";`).join("\n");
-  const entries = apps.map((a) => `    "${a.route}": asApp(await ${a.fn}()),`).join("\n");
+  const entries = apps
+    .filter((a) => a.route !== "rag")
+    .map((a) => `    "${a.route}": asApp(await ${a.fn}()),`)
+    .join("\n");
+
+  // RAG is the one app that can fail at startup: it needs an embeddings
+  // provider, and providers without one fall back to another provider's key.
+  // Build it in a try/catch so a missing key costs /rag, not every route.
+  const ragInit = apps.some((a) => a.route === "rag")
+    ? `  let ragApp: AppGraph | undefined;
+  try {
+    ragApp = asApp(await createRagApp());
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(\`RAG app unavailable (embeddings failed): \${msg}\`);
+    console.warn("  /rag routes are disabled; every other app still works.");
+  }
+
+`
+    : "";
+  const ragEntry = apps.some((a) => a.route === "rag")
+    ? `\n    ...(ragApp ? { rag: ragApp } : {}),`
+    : "";
 
   return `import "./config/env";
 import { fastify, type FastifyError, type FastifyReply, type FastifyRequest } from "fastify";
@@ -554,8 +576,8 @@ server.setErrorHandler(async (error: FastifyError, _req: FastifyRequest, reply: 
 });
 
 async function start() {
-  const apps: Record<string, AppGraph> = {
-${entries}
+${ragInit}  const apps: Record<string, AppGraph> = {
+${entries}${ragEntry}
   };
 
   const getApp = (name: string) => {

--- a/create-langgraph-app/package.json
+++ b/create-langgraph-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-langgraph-app",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Scaffold a new LangGraph multi-agent project in seconds",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Closes #6.

## What

Selecting **RAG** in `npx create-langgraph-app` generated an agent with no retrieval — `tools: []`, a `TODO`, and a link back to this repo. The pattern was in the menu but not in the output. This generates the real implementation.

- **`src/tools/rag.ts`** — chunking, embedding, cosine-similarity search over an in-memory store, exposed as a proper `tool()` with a zod schema so `createAgent` can bind it
- **`src/apps/rag.ts`** — memoized index wired to the retrieval tool
- **`src/config/embeddings.ts`** — validated lazily inside `createEmbeddings()`, so a project that never touches RAG needs no embeddings key, and a bad value costs the RAG route rather than the whole process

## Embeddings

Anthropic, Groq and DeepSeek have no embeddings API, so those scaffolds resolve embeddings to OpenAI, install that SDK **alongside** the chat SDK, and say so in the generated `.env`:

```
anthropic  -> @langchain/anthropic, @langchain/openai
deepseek   -> @langchain/deepseek, @langchain/openai
ollama     -> @langchain/ollama
openai     -> @langchain/openai
```

The scaffold installs one embeddings SDK, so the generated config imports only that one; switching `EMBEDDINGS_PROVIDER` afterwards raises a clear error naming what to install rather than failing on an unresolved import.

Also: `@langchain/textsplitters` was already added as a RAG dependency but never used. It now is.

## Verification

- [x] Scaffolder compile guard (#8) passes — all patterns together and each alone
- [x] Generated deps include the embeddings SDK for every provider (table above)
- [x] **Ran a generated Ollama project end to end**: indexed 3 chunks with real embeddings, answered from them, and cited the retrieved passage
- [x] Retrieval discriminates — `"peer agents hand off control"` scores the swarm chunk **0.73** vs 0.54 / 0.42 for the others
- [x] `npm test` (61) and typecheck pass with no `.env`; scaffolder builds; `dist/create.js` still prompts

## Credit

The cosine helper guards the zero vector (returns `0` rather than `NaN`) — an improvement over the kit's own version, taken from @JinhangHE126's approach in #7.
