### PR TITLE
fix(rag): guard cosine similarity against zero vectors

### DIFF
--- a/src/tools/rag.ts
+++ b/src/tools/rag.ts
@@ -18,7 +18,8 @@ function cosineSimilarity(a: number[], b: number[]): number {
     normA += a[i] * a[i];
     normB += b[i] * b[i];
   }
-  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+  // A zero vector would otherwise yield NaN, which sorts unpredictably.
+  return normA === 0 || normB === 0 ? 0 : dot / (Math.sqrt(normA) * Math.sqrt(normB));
 }
 
 export class InMemoryVectorStore {

--- a/tests/tools/rag.test.ts
+++ b/tests/tools/rag.test.ts
@@ -57,6 +57,25 @@ describe("InMemoryVectorStore", () => {
     const results = await store.search("cats", 2);
     expect(results).toHaveLength(2);
   });
+
+  it("ranks zero-vector documents at a stable zero score", async () => {
+    const zeroVectorEmbeddings = {
+      embedDocuments: vi.fn(async () => [[0, 0], [1, 0]]),
+      embedQuery: vi.fn(async () => [1, 0]),
+    } as unknown as Embeddings;
+    const store = new InMemoryVectorStore(zeroVectorEmbeddings);
+    const { Document } = await import("@langchain/core/documents");
+
+    await store.addDocuments([
+      new Document({ pageContent: "zero vector" }),
+      new Document({ pageContent: "matching vector" }),
+    ]);
+
+    await expect(store.search("query", 2)).resolves.toEqual([
+      "matching vector",
+      "zero vector",
+    ]);
+  });
 });
 
 describe("buildVectorStore", () => {


### PR DESCRIPTION
## What

Guard `cosineSimilarity` against zero-length vectors by returning a score of `0` when either input has zero norm. Add a regression test through `InMemoryVectorStore` that verifies a zero-vector document no longer sorts ahead of a matching document.

## Why

Closes #10.

Without the guard, a zero vector produces `NaN`, and the comparator cannot order that result reliably. This also keeps the hand-written RAG implementation consistent with the guarded version generated by the scaffolder.

## Compatibility

The change affects only the zero-vector edge case. Normal cosine-similarity scores and the public vector-store API are unchanged.

## How to test

- [x] `npm test -- tests/tools/rag.test.ts` — 7 passed.
- [x] `npm test -- --exclude tests/scaffolder/generated-project.test.ts` — 55 passed.
- [x] `npm run typecheck` — passed.
- [x] `npm run lint` — passed (the repository maps this script to `tsc --noEmit`).
- [ ] Manual `npm run dev`/`npm run dev:http` testing — not run; this change is covered by the offline unit test and does not require an LLM provider.

The complete local `npm test` run produced 55 passed and 7 failed. All seven failures are in the unchanged scaffolder test file and fail while creating a temporary `node_modules` symlink with Windows `EPERM`; the other ten test files passed. Ubuntu CI should provide the repository's supported full-suite result.

## AI disclosure

- Model/tool: OpenAI Codex (GPT-5-based) via the Codex desktop app.
- Review/uncertainty: I verified the fix through the public `InMemoryVectorStore.search` path, including the stored zero-vector case that previously produced unstable ordering. The private helper is not exported, so the regression intentionally exercises the supported store API rather than adding a testing-only export.
- Real test output is recorded above; the Windows-only full-suite limitation is the only check that did not pass locally.
