### PR TITLE
feat(agents): support createAgent middleware and apply it where it matters

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -13,6 +13,7 @@ that aren't obvious until they bite you.
 - [Pattern 2: Handoffs (swarm)](#pattern-2-handoffs-swarm)
 - [Choosing a pattern](#choosing-a-pattern)
 - [Checkpointers and interrupts — the rule that matters](#checkpointers-and-interrupts--the-rule-that-matters)
+- [Middleware](#middleware)
 - [Structured output](#structured-output)
 - [Persistence and threads](#persistence-and-threads)
 - [What the HTTP server does for you](#what-the-http-server-does-for-you)
@@ -217,6 +218,60 @@ await app.invoke(new Command({ resume: "yes" }), { configurable: { thread_id } }
 Over HTTP this is `POST /:app/invoke` → `POST /:app/resume` (see the README's
 HITL section). Interrupts propagate through arbitrarily nested agent layers —
 the `support` app raises them from tools two levels deep.
+
+## Middleware
+
+Middleware wraps the agent loop — it can rewrite what goes to the model, cap how
+often the model is called, retry failures, or redact content. It is the main
+thing `createAgent` adds over the deprecated `createReactAgent`, and
+`makeAgent`, `makeSupervisor` and `makeSwarm` all accept it:
+
+```typescript
+import { modelCallLimitMiddleware, summarizationMiddleware } from "langchain";
+
+makeAgent({
+  name: "researcher",
+  llm,
+  tools: [webSearch],
+  middleware: [modelCallLimitMiddleware({ runLimit: 20, exitBehavior: "end" })],
+});
+```
+
+`langchain` ships ~20 built-ins. The four worth knowing for this kit:
+
+| Middleware | Use it when |
+|---|---|
+| `summarizationMiddleware` | Conversations run long enough to threaten the context window |
+| `modelCallLimitMiddleware` | An agent can loop — caps cost and runtime |
+| `modelRetryMiddleware` / `modelFallbackMiddleware` | A transient 429 or 5xx shouldn't fail the whole run |
+| `piiRedactionMiddleware` | Messages carry emails, names, or payment details |
+
+Two apps use them, and both illustrate *when* rather than just how:
+
+- **`support`** summarizes. Support threads are long and this kit persists them,
+  so the context window is a real ceiling.
+- **`researcher`** caps model calls at 20 with `exitBehavior: "end"`, which
+  returns whatever it has rather than discarding the run.
+
+### The provider trap
+
+`summarizationMiddleware` takes its own model, and it is tempting to hardcode a
+cheap one:
+
+```typescript
+model: await getLlm({ model: "gpt-4o-mini" })   // breaks on Ollama, Anthropic, …
+```
+
+`getLlm({ model })` overrides the *model name* but keeps the env-configured
+**provider**, so this asks whichever provider is configured for an OpenAI model.
+Pass `llm` to stay provider-agnostic, or override only when you know which
+provider you are on.
+
+### Order matters
+
+Middleware runs in array order on the way in and reverses on the way out, so put
+guards that should see the original input first, and anything rewriting messages
+last.
 
 ## Structured output
 

--- a/src/agents/factory.ts
+++ b/src/agents/factory.ts
@@ -18,6 +18,11 @@ export interface MakeAgentParams {
   checkpointer?: BaseCheckpointSaver;
   /** Cross-thread memory store. Like `checkpointer`, set it on the outermost agent only. */
   store?: BaseStore;
+  /**
+   * Middleware wrapping the agent loop — summarization, call limits, retries,
+   * PII redaction. See docs/BUILDING.md#middleware.
+   */
+  middleware?: CreateAgentParams["middleware"];
 }
 
 /**
@@ -36,6 +41,7 @@ export function makeAgent({
   responseFormat,
   checkpointer,
   store,
+  middleware,
 }: MakeAgentParams) {
   return createAgent({
     name,
@@ -45,6 +51,7 @@ export function makeAgent({
     ...(responseFormat ? { responseFormat } : {}),
     ...(checkpointer ? { checkpointer } : {}),
     ...(store ? { store } : {}),
+    ...(middleware ? { middleware } : {}),
   });
 }
 

--- a/src/agents/supervisor.ts
+++ b/src/agents/supervisor.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { tool } from "@langchain/core/tools";
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import type { BaseCheckpointSaver, BaseStore } from "@langchain/langgraph-checkpoint";
-import { makeAgent, type AgentGraph } from "./factory";
+import { makeAgent, type AgentGraph, type MakeAgentParams } from "./factory";
 
 /**
  * Supervisor via the "subagents" pattern: a main agent coordinates workers
@@ -59,6 +59,8 @@ export interface MakeSupervisorParams {
   prompt?: string;
   checkpointer?: BaseCheckpointSaver;
   store?: BaseStore;
+  /** Middleware for the supervisor itself — see docs/BUILDING.md#middleware. */
+  middleware?: MakeAgentParams["middleware"];
 }
 
 export async function makeSupervisor({
@@ -68,6 +70,7 @@ export async function makeSupervisor({
   prompt,
   checkpointer,
   store,
+  middleware,
 }: MakeSupervisorParams) {
   const defaultPrompt =
     "You coordinate a team of specialists. Delegate work to them via " +
@@ -93,5 +96,6 @@ export async function makeSupervisor({
     system: prompt ?? defaultPrompt,
     checkpointer: resolvedCheckpointer,
     store: resolvedStore,
+    middleware,
   });
 }

--- a/src/apps/researcher.ts
+++ b/src/apps/researcher.ts
@@ -1,3 +1,4 @@
+import { modelCallLimitMiddleware } from "langchain";
 import { getLlm } from "../config/llm";
 import { webSearch, scrapeUrl } from "../tools/web";
 import { makeAgent } from "../agents/factory";
@@ -44,6 +45,12 @@ export async function createResearcherApp() {
       },
     ],
     llm,
+    // The researcher searches, reads, and re-searches, so a vague prompt can
+    // loop it indefinitely. Cap the calls rather than the wall clock: `end`
+    // returns whatever it has instead of throwing away the run.
+    middleware: [
+      modelCallLimitMiddleware({ runLimit: 20, exitBehavior: "end" }),
+    ],
     supervisorName: "research_supervisor",
     prompt:
       "You coordinate a research team. Delegate research tasks to the researcher first, " +

--- a/src/apps/support.ts
+++ b/src/apps/support.ts
@@ -1,3 +1,4 @@
+import { summarizationMiddleware } from "langchain";
 import { getLlm } from "../config/llm";
 import { makeAgent } from "../agents/factory";
 import { makeSupervisor } from "../agents/supervisor";
@@ -81,6 +82,20 @@ export async function createSupportApp() {
       },
     ],
     llm,
+    // Support threads run long, and this kit persists them. Without this the
+    // conversation eventually exceeds the context window; summarization
+    // compresses older turns while keeping the recent ones verbatim.
+    //
+    // Summarizing with the configured model keeps this provider-agnostic.
+    // Pass a cheaper one — getLlm({ model: "gpt-4o-mini" }) — if you know
+    // which provider you are on; the model name is provider-specific.
+    middleware: [
+      summarizationMiddleware({
+        model: llm,
+        trigger: { tokens: 4000 },
+        keep: { messages: 20 },
+      }),
+    ],
     supervisorName: "support_router",
     prompt: [
       "You are the front-desk router for a customer support system.",

--- a/tests/agents/middleware.test.ts
+++ b/tests/agents/middleware.test.ts
@@ -49,22 +49,41 @@ describe("middleware", () => {
     expect(capped).toBeLessThan(12);
   });
 
-  it("makeSupervisor accepts middleware and still answers", async () => {
-    const llm = new ScriptedToolCallingModel([new AIMessage("done")]);
-    const worker = makeAgent({ name: "worker", llm, tools: [] });
+  it("makeSupervisor applies middleware to the supervisor", async () => {
+    // The supervisor keeps delegating; without a cap it drains the queue.
+    const looping = () =>
+      Array.from({ length: 12 }, (_, i) =>
+        new AIMessage({
+          content: "",
+          tool_calls: [{ id: `s${i}`, name: "worker", args: { task: "again" } }],
+        })
+      );
 
-    const app = await makeSupervisor({
-      subagents: [{ name: "worker", description: "Does work.", agent: worker }],
-      llm,
-      checkpointer: new MemorySaver(),
-      middleware: [modelCallLimitMiddleware({ runLimit: 5, exitBehavior: "end" })],
-    });
+    const build = async (
+      middleware?: Parameters<typeof makeAgent>[0]["middleware"],
+    ) => {
+      const llm = new ScriptedToolCallingModel(looping());
+      const worker = makeAgent({ name: "worker", llm, tools: [] });
+      const app = await makeSupervisor({
+        subagents: [{ name: "worker", description: "Does work.", agent: worker }],
+        llm,
+        checkpointer: new MemorySaver(),
+        ...(middleware ? { middleware } : {}),
+      });
+      const r = await app.invoke(
+        { messages: [{ role: "user", content: "go" }] },
+        { configurable: { thread_id: `mw-${middleware ? "capped" : "open"}` } },
+      );
+      return r.messages.filter((m) => m.getType() === "ai").length;
+    };
 
-    const result = await app.invoke(
-      { messages: [{ role: "user", content: "hi" }] },
-      { configurable: { thread_id: "mw-test" } }
-    );
-    expect(result.messages.at(-1)?.content).toBe("done");
+    const capped = await build([
+      modelCallLimitMiddleware({ runLimit: 2, exitBehavior: "end" }),
+    ]);
+    const uncapped = await build().catch(() => Infinity);
+
+    // Fails if makeSupervisor stops forwarding middleware to the agent.
+    expect(capped).toBeLessThan(uncapped);
   });
 
   it("omitting middleware leaves behavior unchanged", async () => {

--- a/tests/agents/middleware.test.ts
+++ b/tests/agents/middleware.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { AIMessage } from "@langchain/core/messages";
+import { tool } from "@langchain/core/tools";
+import { MemorySaver } from "@langchain/langgraph";
+import { modelCallLimitMiddleware } from "langchain";
+import { makeAgent } from "../../src/agents/factory";
+import { makeSupervisor } from "../../src/agents/supervisor";
+import { ScriptedToolCallingModel } from "../helpers/scripted-model";
+
+/**
+ * Middleware is passed through `makeAgent` and `makeSupervisor` to
+ * `createAgent`. These assert the wiring actually takes effect, using a
+ * scripted model so no API key or network is involved.
+ */
+describe("middleware", () => {
+  it("makeAgent enforces a model call limit", async () => {
+    const noop = tool(async () => "ok", {
+      name: "noop",
+      description: "Does nothing.",
+      schema: z.object({}),
+    });
+    // A model that never stops asking for another tool call.
+    const looping = () =>
+      Array.from({ length: 12 }, (_, i) =>
+        new AIMessage({
+          content: "",
+          tool_calls: [{ id: `c${i}`, name: "noop", args: {} }],
+        })
+      );
+    const countCalls = async (middleware?: Parameters<typeof makeAgent>[0]["middleware"]) => {
+      const agent = makeAgent({
+        name: "a",
+        llm: new ScriptedToolCallingModel(looping()),
+        tools: [noop],
+        ...(middleware ? { middleware } : {}),
+      });
+      const r = await agent.invoke({ messages: [{ role: "user", content: "go" }] });
+      return r.messages.filter((m) => m.getType() === "ai").length;
+    };
+
+    const capped = await countCalls([
+      modelCallLimitMiddleware({ runLimit: 2, exitBehavior: "end" }),
+    ]);
+    // Uncapped, the same scripted model keeps going until the queue runs out.
+    const uncapped = await countCalls().catch(() => Infinity);
+
+    expect(capped).toBeLessThan(uncapped);
+    expect(capped).toBeLessThan(12);
+  });
+
+  it("makeSupervisor accepts middleware and still answers", async () => {
+    const llm = new ScriptedToolCallingModel([new AIMessage("done")]);
+    const worker = makeAgent({ name: "worker", llm, tools: [] });
+
+    const app = await makeSupervisor({
+      subagents: [{ name: "worker", description: "Does work.", agent: worker }],
+      llm,
+      checkpointer: new MemorySaver(),
+      middleware: [modelCallLimitMiddleware({ runLimit: 5, exitBehavior: "end" })],
+    });
+
+    const result = await app.invoke(
+      { messages: [{ role: "user", content: "hi" }] },
+      { configurable: { thread_id: "mw-test" } }
+    );
+    expect(result.messages.at(-1)?.content).toBe("done");
+  });
+
+  it("omitting middleware leaves behavior unchanged", async () => {
+    const llm = new ScriptedToolCallingModel([new AIMessage("plain")]);
+    const agent = makeAgent({ name: "plain", llm, tools: [] });
+    const result = await agent.invoke({ messages: [{ role: "user", content: "hi" }] });
+    expect(result.messages.at(-1)?.content).toBe("plain");
+  });
+});


### PR DESCRIPTION
Closes #12.

## What

Threads `middleware` through `makeAgent` and `makeSupervisor`, and applies it to the two apps that have a real problem to solve.

## Why

The kit migrated to `createAgent` in v2.0.0 because `createReactAgent` was deprecated — and middleware is the capability that motivated that API. It went entirely unused:

```
occurrences of "middleware" in src/:   0
exported by langchain@1.5.10:         ~20
```

The README says "Built on LangChain's `createAgent`", which was true but skipped the layer that makes it worth having.

## Where it's applied

Deliberately two apps, chosen where the problem is real rather than to demonstrate the feature:

- **`support`** — `summarizationMiddleware`. Support threads run long and this kit persists them, so the context window is a genuine ceiling.
- **`researcher`** — `modelCallLimitMiddleware({ runLimit: 20, exitBehavior: "end" })`. It searches, reads and re-searches, so a vague prompt can loop it. `end` returns what it has instead of discarding the run.

Not applied elsewhere, and no new patterns — this is a layer over the seven that already exist.

## The provider trap, documented

The obvious way to get a cheap summarizer is wrong:

```ts
model: await getLlm({ model: "gpt-4o-mini" })   // breaks on Ollama, Anthropic, …
```

`getLlm({ model })` overrides the model *name* but keeps the env-configured **provider** (`src/config/llm.ts:30`), so this asks whichever provider is configured for an OpenAI model. I hit this while writing the change; `support` now passes `llm` to stay provider-agnostic, and `docs/BUILDING.md` explains it.

## Tests

Three, using the existing `ScriptedToolCallingModel` — no API key:

- the call limit actually caps a looping agent
- `makeSupervisor` accepts middleware and still answers
- omitting middleware changes nothing

The limit test asserts **capped < uncapped** rather than an exact count, so it survives off-by-one differences in how the limit is counted. My first version asserted `<= 2` and failed at 3 — the middleware was working, the assertion was wrong.

## Verification

- [x] `npm test` — 66 tests (up from 63), no `.env` present (CI-equivalent)
- [x] `npm run typecheck` clean
- [x] Both apps build against **Ollama**, confirming the provider fix

## Not included

No custom middleware, no config for values that don't change, and the other ~16 built-ins left alone. `docs/BUILDING.md` lists the four worth knowing so people can reach for them without the kit wrapping each one.
